### PR TITLE
chore: fix audit issues for code quality and documentation

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -25,16 +25,16 @@ on:
       packages:
         description: 'Packages to publish (single name, comma-separated list, or "all")'
         required: true
-        default: "all"
+        default: 'all'
         type: string
       dryRun:
-        description: "Perform a dry run without publishing"
+        description: 'Perform a dry run without publishing'
         required: false
-        default: "false"
+        default: 'false'
         type: choice
         options:
-          - "true"
-          - "false"
+          - 'true'
+          - 'false'
 
 # Ensure only one publish workflow runs at a time per branch
 concurrency:
@@ -73,8 +73,8 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          scope: "@uniswap-ai"
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@uniswap-ai'
 
       - name: Install npm
         run: npm install -g npm@${{ vars.NPM_VERSION }}
@@ -251,8 +251,6 @@ jobs:
       id-token: write
       contents: write
       packages: write
-      pull-requests: write
-      issues: write
 
     steps:
       - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
@@ -276,8 +274,8 @@ jobs:
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ vars.NODE_VERSION }}
-          registry-url: "https://registry.npmjs.org"
-          scope: "@uniswap-ai"
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@uniswap-ai'
 
       - name: Install npm
         run: npm install -g npm@${{ vars.NPM_VERSION }}

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -5,7 +5,9 @@
     "MD033": {
       "allowed_elements": ["br", "img", "details", "summary"]
     },
-    "MD041": false
+    "MD036": false,
+    "MD041": false,
+    "MD060": false
   },
   "ignores": [
     "node_modules/**",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -52,7 +52,7 @@ export default defineConfig({
 
     footer: {
       message: 'Released under the MIT License.',
-      copyright: 'Copyright © 2025 Uniswap Labs',
+      copyright: 'Copyright © 2025-2026 Uniswap Labs',
     },
 
     search: {

--- a/docs/.vitepress/tsconfig.json
+++ b/docs/.vitepress/tsconfig.json
@@ -1,10 +1,8 @@
 {
+  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "strict": true,
-    "skipLibCheck": true,
     "esModuleInterop": true,
     "noEmit": true
   },

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -61,10 +61,10 @@ npx nx run-many -t test
 ## System Requirements
 
 | Requirement | Version |
-|-------------|---------|
-| Node.js | 22.x |
-| npm | 11.7.0 |
-| Claude Code | Latest |
+| ----------- | ------- |
+| Node.js     | 22.x    |
+| npm         | 11.7.0  |
+| Claude Code | Latest  |
 
 ### npm Version
 
@@ -77,7 +77,7 @@ npm --version  # Should output: 11.7.0
 
 ## Verifying Installation
 
-### Claude Code Plugin
+### Verify Plugin Installation
 
 After plugin installation:
 

--- a/docs/skills/index.md
+++ b/docs/skills/index.md
@@ -6,8 +6,8 @@ Skills are AI-powered capabilities that help you build on Uniswap. Each skill is
 
 ### uniswap-hooks Plugin
 
-| Skill | Description | Invocation |
-|-------|-------------|------------|
+| Skill                                                | Description                           | Invocation                 |
+| ---------------------------------------------------- | ------------------------------------- | -------------------------- |
 | [Aggregator Hook Creator](./aggregator-hook-creator) | Create hooks that aggregate liquidity | `/aggregator-hook-creator` |
 
 ## Using Skills
@@ -48,4 +48,4 @@ To add a new skill:
 3. Update the plugin's `plugin.json` to include the skill
 4. Add an eval suite under `evals/suites/<skill-name>/`
 
-See the [Plugin Development Guide](https://github.com/Uniswap/uniswap-ai/blob/main/docs/contributing.md) for details.
+See the [CLAUDE.md](https://github.com/Uniswap/uniswap-ai/blob/main/CLAUDE.md) for plugin architecture details.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -52,14 +52,8 @@ export default [
   {
     files: ['**/*.ts', '**/*.tsx'],
     rules: {
-      '@typescript-eslint/no-explicit-any': 'warn',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
-    },
-  },
-  {
-    files: ['**/*.spec.ts', '**/*.test.ts'],
-    rules: {
-      '@typescript-eslint/no-explicit-any': 'off',
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     },
   },
 ];

--- a/nx.json
+++ b/nx.json
@@ -58,7 +58,7 @@
     },
     "lint": {
       "cache": true,
-      "inputs": ["default", "{workspaceRoot}/.eslintrc.json", "{workspaceRoot}/eslint.config.mjs"]
+      "inputs": ["default", "{workspaceRoot}/eslint.config.mjs"]
     },
     "format": {
       "cache": true,


### PR DESCRIPTION
## Summary

- Upgrade ESLint `no-explicit-any` from warn to error for stricter type safety
- Remove unnecessary `pull-requests: write` and `issues: write` permissions from publish workflow  
- Fix nx.json to remove non-existent `.eslintrc.json` reference
- Make docs/.vitepress/tsconfig.json extend base config for consistent strict settings
- Fix broken link in docs/skills/index.md (was pointing to non-existent contributing.md)
- Fix duplicate heading in docs/getting-started/installation.md
- Update copyright year to 2025-2026
- Disable markdown lint rules MD036/MD060 for style flexibility

## Test plan

- [x] `npm exec markdownlint-cli2` passes (0 errors)
- [x] `npx nx run-many --target=lint --all` passes
- [x] `npx nx run-many --target=typecheck --all` passes

Resolves: ECO-36