### PR TITLE
fix(ci): prevent evals workflow from staying pending on unrelated PRs

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -2,10 +2,6 @@ name: Evals
 
 on:
   pull_request:
-    paths:
-      - 'packages/plugins/**'
-      - 'evals/**'
-      - '.github/workflows/evals.yml'
   workflow_dispatch:
     inputs:
       suite:
@@ -23,9 +19,37 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  check-paths:
+    name: Check Changed Paths
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.evals }}
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
+
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Check for eval-related changes
+        id: filter
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        with:
+          filters: |
+            evals:
+              - 'packages/plugins/**'
+              - 'evals/**'
+              - '.github/workflows/evals.yml'
+
   eval:
     name: Run Evaluations
     runs-on: ubuntu-latest
+    needs: check-paths
+    # Run if: paths changed OR workflow_dispatch (manual trigger)
+    if: needs.check-paths.outputs.should_run == 'true' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
## Summary
The evals workflow used path filtering (`on.pull_request.paths`) which caused it to never start for PRs that didn't touch eval-related files. When combined with required status checks, this resulted in PRs being stuck at "Pending" indefinitely waiting for a check that would never run.

## Changes
Split the workflow into two jobs:
- **check-paths**: Always runs (~10s), uses `dorny/paths-filter` to detect if relevant paths changed
- **eval**: Runs only if paths changed OR manual dispatch, skips gracefully otherwise

## Behavior
| Scenario | `check-paths` | `eval` |
|----------|---------------|--------|
| PR touches `evals/` | ✅ runs | ✅ runs |
| PR touches `packages/plugins/` | ✅ runs | ✅ runs |
| PR touches only `docs/` | ✅ runs | ⏭️ skipped |
| Manual dispatch | ✅ runs | ✅ runs |

## Test plan
- [ ] Create a PR that only touches `docs/` - verify evals workflow shows as skipped (not pending)
- [ ] Create a PR that touches `evals/` - verify evals workflow runs normally

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Fix the evals workflow staying in "Pending" state indefinitely for PRs that don't touch eval-related files. The workflow used `on.pull_request.paths` filtering which caused it to never start for unrelated PRs, blocking merge when combined with required status checks.
## Changes
### Workflow Architecture
- Remove `paths` filter from `pull_request` trigger to ensure workflow always starts
- Add new `check-paths` job that runs quickly (~10s) using `dorny/paths-filter@v3.0.2`
- Make `eval` job conditional on path check results OR manual workflow dispatch
- Add proper permissions (`contents: read`, `pull-requests: read`) for path filtering
### Behavior Matrix
| Scenario | `check-paths` | `eval` |
|----------|---------------|--------|
| PR touches `evals/` | ✅ runs | ✅ runs |
| PR touches `packages/plugins/` | ✅ runs | ✅ runs |
| PR touches only `docs/` | ✅ runs | ⏭️ skipped |
| Manual dispatch | ✅ runs | ✅ runs |
## Notes
This pattern is a common solution for GitHub Actions' limitation where path-filtered workflows don't report a "skipped" status—they simply never run. By always running a lightweight job that checks paths internally, we ensure the workflow reports a status while still skipping expensive operations when unnecessary.
## Test plan
- [ ] Create a PR that only touches `docs/` - verify evals workflow shows as skipped (not pending)
- [ ] Create a PR that touches `evals/` - verify evals workflow runs normally
- [ ] Trigger manual workflow dispatch - verify eval job runs
<!-- claude-pr-description-end -->