### PR TITLE
chore(evals): add eval scaffolds and update docs for new plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,9 @@ uniswap-ai/
 │   └── templates/           # Templates for new suites
 ├── packages/
 │   ├── plugins/             # Claude Code plugins
-│   │   └── uniswap-hooks/   # Uniswap V4 hooks plugin
+│   │   ├── uniswap-hooks/   # Uniswap V4 hooks plugin
+│   │   ├── uniswap-viem/    # EVM blockchain integration (viem/wagmi)
+│   │   └── uniswap-trading/ # Uniswap swap integration
 │   ├── sdk/                 # TypeScript SDKs
 │   ├── prompts/             # Shared prompt templates
 │   └── utils/               # Shared utilities

--- a/docs/plans/eco-81-migration-plan.md
+++ b/docs/plans/eco-81-migration-plan.md
@@ -1,0 +1,371 @@
+# ECO-81: Migration Plan - uniswap-trading Plugin to uniswap-ai
+
+**Linear task**: [ECO-81](https://linear.app/uniswap/issue/ECO-81/move-uniswap-trading-plugin-to-uniswap-ai-repository)
+**Status**: Reviewed (pending Q approval)
+**Date**: 2026-02-10
+
+## Executive Summary
+
+Migrate the `uniswap-trading` plugin from `ai-toolkit` to `uniswap-ai`, splitting it into **two focused plugins** that follow Claude Code marketplace best practices for single-responsibility plugins.
+
+## Current State
+
+### Source Plugin (ai-toolkit)
+
+Location: `ai-toolkit/packages/plugins/uniswap-trading/`
+
+| Component                 | Type                        | Category | Lines  |
+| ------------------------- | --------------------------- | -------- | ------ |
+| `viem-integration`        | Skill (+ 6 reference files) | Tooling  | ~3,130 |
+| `swap-integration`        | Skill                       | Protocol | ~1,006 |
+| `viem-integration-expert` | Agent                       | Tooling  | ~50    |
+| `swap-integration-expert` | Agent                       | Protocol | ~70    |
+
+- **Zero runtime dependencies** -- pure markdown/documentation plugin
+- **No commands, hooks, or MCP servers**
+- **No build artifacts** -- nothing to compile
+
+### Target Repository (uniswap-ai)
+
+- Nx monorepo with one existing plugin (`uniswap-hooks`)
+- Well-established conventions for plugin structure, validation, CI/CD
+- Eval framework requiring coverage for every skill
+
+## Decision: Split into Two Plugins
+
+### Rationale
+
+The current `uniswap-trading` plugin bundles two distinct concerns:
+
+1. **Generic EVM tooling** (viem/wagmi) -- Not Uniswap-specific at all. Useful for any EVM developer.
+2. **Uniswap protocol integration** (swaps) -- Deeply Uniswap-specific.
+
+Splitting follows the single-responsibility principle and Claude Code marketplace best practices:
+
+- Developers who only need viem/wagmi help don't need to install swap-specific content
+- Developers who already know viem can install just the swap plugin
+- Each plugin has a clear, discoverable purpose in the marketplace
+- Smaller, focused plugins are easier to maintain, version, and evaluate
+
+### Additional Consideration: wagmi-react.md
+
+The `wagmi-react.md` reference file within viem-integration is **frontend/React-specific** (useAccount, useConnect, useReadContract, useWriteContract, useSwitchChain). This is the "UI coupling" mentioned in the task description.
+
+**Recommendation**: Keep `wagmi-react.md` in the viem plugin. It's a reference file within the viem-integration skill, not a standalone skill. Splitting it out would break the skill's completeness without meaningful benefit. The viem plugin naturally covers both Node.js and React usage patterns -- that's the scope of viem/wagmi as libraries.
+
+## Proposed Plugin Architecture
+
+### Plugin 1: `uniswap-viem` (NEW)
+
+**Purpose**: Foundational EVM blockchain integration using viem and wagmi.
+
+```text
+packages/plugins/uniswap-viem/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   └── viem-integration-expert.md
+├── skills/
+│   └── viem-integration/
+│       ├── viem-integration.md
+│       ├── SKILL.md -> viem-integration.md
+│       └── references/
+│           ├── clients-and-transports.md
+│           ├── reading-data.md
+│           ├── writing-transactions.md
+│           ├── accounts-and-keys.md
+│           ├── contract-patterns.md
+│           └── wagmi-react.md
+├── project.json
+├── package.json
+├── CLAUDE.md
+└── README.md
+```
+
+**Naming rationale**: `uniswap-viem` clearly identifies this as viem/wagmi tooling within the Uniswap ecosystem. Alternative considered: `evm-toolkit` -- rejected because the `@uniswap` scope already establishes context, and `viem` is more specific/discoverable than `evm`.
+
+**Note on reference file reorganization**: The current structure places reference files as siblings of the main skill file. The uniswap-hooks reference pattern uses a `references/` subdirectory. We adopt the `references/` pattern for consistency with the target repo.
+
+### Plugin 2: `uniswap-trading` (RENAMED from uniswap-trading)
+
+**Purpose**: Uniswap swap integration via Trading API, Universal Router, and SDKs.
+
+```text
+packages/plugins/uniswap-trading/
+├── .claude-plugin/
+│   └── plugin.json
+├── agents/
+│   └── swap-integration-expert.md
+├── skills/
+│   └── swap-integration/
+│       ├── swap-integration.md
+│       └── SKILL.md -> swap-integration.md
+├── project.json
+├── package.json
+├── CLAUDE.md
+└── README.md
+```
+
+**Naming rationale**: Renamed from `uniswap-trading` to `uniswap-trading` per domain expert review. "Builder" is overly generic and undiscoverable -- a developer searching for "Uniswap swap" or "Uniswap trading" won't find "builder" intuitively. "Trading" best covers Trading API, swaps, and potential future features (limit orders, Dutch auctions). Alternative considered: `uniswap-swaps` -- also viable but more limiting.
+
+### Cross-Plugin Dependency
+
+`swap-integration` skill currently references `../viem-integration/viem-integration.md` as a prerequisite. After splitting:
+
+- **Remove the relative path reference** (it will be cross-plugin, not cross-directory)
+- **Add a textual note** in the swap-integration skill: "This skill assumes familiarity with viem basics. Install the `uniswap-viem` plugin for comprehensive viem/wagmi guidance."
+- **Add a `relatedPlugins` note** in the swap-integration plugin's CLAUDE.md and README.md
+
+This is a soft dependency (documentation reference), not a hard dependency. The swap skill works independently -- it just recommends the viem skill for prerequisite knowledge.
+
+## File-by-File Migration Map
+
+### Plugin 1: uniswap-viem
+
+| Source (ai-toolkit)                                 | Target (uniswap-ai)                                                                          | Action                         |
+| --------------------------------------------------- | -------------------------------------------------------------------------------------------- | ------------------------------ |
+| `skills/viem-integration/viem-integration.md`       | `packages/plugins/uniswap-viem/skills/viem-integration/viem-integration.md`                  | Copy + update cross-references |
+| `skills/viem-integration/SKILL.md`                  | `packages/plugins/uniswap-viem/skills/viem-integration/SKILL.md`                             | Recreate symlink               |
+| `skills/viem-integration/clients-and-transports.md` | `packages/plugins/uniswap-viem/skills/viem-integration/references/clients-and-transports.md` | Copy (move into references/)   |
+| `skills/viem-integration/reading-data.md`           | `packages/plugins/uniswap-viem/skills/viem-integration/references/reading-data.md`           | Copy (move into references/)   |
+| `skills/viem-integration/writing-transactions.md`   | `packages/plugins/uniswap-viem/skills/viem-integration/references/writing-transactions.md`   | Copy (move into references/)   |
+| `skills/viem-integration/accounts-and-keys.md`      | `packages/plugins/uniswap-viem/skills/viem-integration/references/accounts-and-keys.md`      | Copy (move into references/)   |
+| `skills/viem-integration/contract-patterns.md`      | `packages/plugins/uniswap-viem/skills/viem-integration/references/contract-patterns.md`      | Copy (move into references/)   |
+| `skills/viem-integration/wagmi-react.md`            | `packages/plugins/uniswap-viem/skills/viem-integration/references/wagmi-react.md`            | Copy (move into references/)   |
+| `agents/viem-integration-expert.md`                 | `packages/plugins/uniswap-viem/agents/viem-integration-expert.md`                            | Copy + update reference paths  |
+| (none)                                              | `packages/plugins/uniswap-viem/.claude-plugin/plugin.json`                                   | Create new                     |
+| (none)                                              | `packages/plugins/uniswap-viem/package.json`                                                 | Create new                     |
+| (none)                                              | `packages/plugins/uniswap-viem/project.json`                                                 | Create new                     |
+| (none)                                              | `packages/plugins/uniswap-viem/CLAUDE.md`                                                    | Create new                     |
+| (none)                                              | `packages/plugins/uniswap-viem/README.md`                                                    | Create new                     |
+
+### Plugin 2: uniswap-trading
+
+| Source (ai-toolkit)                           | Target (uniswap-ai)                                                            | Action                         |
+| --------------------------------------------- | ------------------------------------------------------------------------------ | ------------------------------ |
+| `skills/swap-integration/swap-integration.md` | `packages/plugins/uniswap-trading/skills/swap-integration/swap-integration.md` | Copy + update cross-references |
+| `skills/swap-integration/SKILL.md`            | `packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md`            | Recreate symlink               |
+| `agents/swap-integration-expert.md`           | `packages/plugins/uniswap-trading/agents/swap-integration-expert.md`           | Copy                           |
+| (none)                                        | `packages/plugins/uniswap-trading/.claude-plugin/plugin.json`                  | Create new                     |
+| (none)                                        | `packages/plugins/uniswap-trading/package.json`                                | Create new                     |
+| (none)                                        | `packages/plugins/uniswap-trading/project.json`                                | Create new                     |
+| (none)                                        | `packages/plugins/uniswap-trading/CLAUDE.md`                                   | Create new                     |
+| (none)                                        | `packages/plugins/uniswap-trading/README.md`                                   | Create new                     |
+
+### Marketplace Config Update
+
+| File                              | Action                                                    |
+| --------------------------------- | --------------------------------------------------------- |
+| `.claude-plugin/marketplace.json` | Add entries for both `uniswap-viem` and `uniswap-trading` |
+
+## Required Modifications
+
+### New Config Files
+
+#### uniswap-viem/plugin.json
+
+```json
+{
+  "name": "uniswap-viem",
+  "version": "1.0.0",
+  "description": "EVM blockchain integration using viem and wagmi - client setup, reading/writing data, accounts, contract interactions, and React hooks",
+  "author": {
+    "name": "Uniswap Labs",
+    "email": "ai-services@uniswap.org"
+  },
+  "homepage": "https://github.com/uniswap/uniswap-ai",
+  "keywords": ["viem", "wagmi", "evm", "blockchain", "ethereum", "web3", "react"],
+  "license": "MIT",
+  "skills": ["./skills/viem-integration"],
+  "commands": ["./skills/viem-integration/viem-integration.md"],
+  "agents": ["./agents/viem-integration-expert.md"]
+}
+```
+
+#### uniswap-trading/plugin.json
+
+```json
+{
+  "name": "uniswap-trading",
+  "version": "1.0.0",
+  "description": "Integrate Uniswap swaps via Trading API, Universal Router SDK, or direct smart contract calls",
+  "author": {
+    "name": "Uniswap Labs",
+    "email": "ai-services@uniswap.org"
+  },
+  "homepage": "https://github.com/uniswap/uniswap-ai",
+  "keywords": ["uniswap", "swap", "defi", "trading-api", "universal-router", "permit2"],
+  "license": "MIT",
+  "skills": ["./skills/swap-integration"],
+  "commands": ["./skills/swap-integration/swap-integration.md"],
+  "agents": ["./agents/swap-integration-expert.md"]
+}
+```
+
+#### package.json (both plugins)
+
+Follow the `uniswap-hooks` pattern:
+
+- `@uniswap/uniswap-viem` and `@uniswap/uniswap-trading`
+- `version: "0.0.1"`, `private: true`
+- Repository URL: `https://github.com/uniswap/uniswap-ai.git`
+- Include `"files": [".claude-plugin", "skills", "agents", "README.md"]`
+
+#### project.json (both plugins)
+
+Follow the `uniswap-hooks` pattern:
+
+- `tags: ["type:plugin", "scope:uniswap"]`
+- Targets: `lint-markdown` and `validate`
+- `$schema` path relative to plugin location
+
+### Content Modifications
+
+1. **viem-integration.md**: Update all internal references to sibling files (e.g., `./clients-and-transports.md`) to use the new `./references/` subdirectory paths (e.g., `./references/clients-and-transports.md`). Remove the "Related Skills" cross-reference to swap-integration (the dependency is one-way: swap references viem, not vice versa).
+2. **swap-integration.md**: Update the prerequisite reference to viem-integration from a relative path to a textual recommendation to install `uniswap-viem` plugin. Also **remove broken links** to non-existent `./trading-api.md` and `./universal-router.md` files (the content is inline, these dead links exist in the source).
+3. **viem-integration-expert.md**: Update all relative paths to reference files (now under `references/` subdirectory, e.g., `../skills/viem-integration/references/...`)
+4. **Skill frontmatter**: Add `name:` field to both skill YAML frontmatter (e.g., `name: viem-integration`, `name: swap-integration`) to match the uniswap-hooks convention
+5. **All files**: Remove any `ai-toolkit` references in content
+6. **Cross-plugin keywords**: Add `"uniswap-trading"` to uniswap-viem plugin.json keywords and `"uniswap-viem"` to uniswap-trading plugin.json keywords for marketplace discoverability
+
+### Note: agents field in plugin.json
+
+The uniswap-hooks reference plugin does not have an `agents` field in its plugin.json (it has no agents). Both new plugins introduce this field as an expansion of the plugin format. The validator does not reject this -- it's a new pattern being established.
+
+### Marketplace Registration
+
+Add to `.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "uniswap-viem",
+  "source": "./packages/plugins/uniswap-viem",
+  "description": "EVM blockchain integration using viem and wagmi"
+},
+{
+  "name": "uniswap-trading",
+  "source": "./packages/plugins/uniswap-trading",
+  "description": "Integrate Uniswap swaps via Trading API, Universal Router, and SDKs"
+}
+```
+
+## Cleanup Recommendations
+
+1. **Remove ai-toolkit coupling**: Update all homepage URLs, repository URLs, and keyword references from `ai-toolkit` to `uniswap-ai`
+2. **Adopt references/ subdirectory pattern**: Move viem reference files into `references/` subdirectory for consistency with `uniswap-hooks` plugin structure
+3. **Update agent reference paths**: The `viem-integration-expert` agent references skill docs via relative paths -- update these to reflect the new `references/` subdirectory
+4. **Add CLAUDE.md files**: Both plugins need CLAUDE.md following the pattern in `uniswap-hooks`
+5. **Agent-agnostic design**: Verify all skills and agents follow the agent-agnostic design rules in `.claude/rules/agent-agnostic.md` (they should already, as they're pure markdown)
+
+## Implementation Sequence
+
+### Phase 1: Create Plugin Scaffolding
+
+1. Create `packages/plugins/uniswap-viem/` directory structure
+2. Create `packages/plugins/uniswap-trading/` directory structure
+3. Write all config files (plugin.json, package.json, project.json)
+4. Write CLAUDE.md and README.md for both plugins
+
+### Phase 2: Copy and Adapt Content
+
+5. Copy viem-integration skill files into `uniswap-viem`, reorganizing reference files into `references/`
+6. Copy viem-integration-expert agent, updating reference paths
+7. Copy swap-integration skill files into `uniswap-trading`
+8. Copy swap-integration-expert agent
+
+### Phase 2.5: Pre-Flight Check
+
+Run markdownlint on source files to identify any formatting issues before migration:
+
+- `npm exec markdownlint-cli2 -- '/Users/nick.koutrelakos/Projects/ai-toolkit.worktrees/next/packages/plugins/uniswap-trading/**/*.md'`
+
+### Phase 3: Update Cross-References and Content
+
+9. Update `viem-integration.md` internal references from `./[file].md` to `./references/[file].md`
+10. Update `swap-integration.md` prerequisite reference to textual recommendation for `uniswap-viem`
+11. Remove broken links to `./trading-api.md` and `./universal-router.md` in swap-integration.md
+12. Update `viem-integration-expert.md` reference file paths for `references/` subdirectory
+13. Add `name:` field to both skill YAML frontmatter
+14. Add cross-plugin keywords to both plugin.json files
+15. Remove all `ai-toolkit` references from content
+
+### Phase 4: Register and Validate
+
+16. Update `.claude-plugin/marketplace.json` with both new plugins
+17. Run `npm install` to update workspace linkage
+18. Run `node scripts/validate-plugin.cjs packages/plugins/uniswap-viem`
+19. Run `node scripts/validate-plugin.cjs packages/plugins/uniswap-trading`
+20. Run `npm exec markdownlint-cli2 -- 'packages/plugins/uniswap-viem/**/*.md'`
+21. Run `npm exec markdownlint-cli2 -- 'packages/plugins/uniswap-trading/**/*.md'`
+
+### Phase 5: Eval Scaffolding
+
+22. Create eval suite scaffold for `viem-integration` in `evals/suites/viem-integration/`
+23. Create eval suite scaffold for `swap-integration` in `evals/suites/swap-integration/`
+24. (Eval content can be developed in a follow-up task)
+
+### Phase 6: Documentation Updates
+
+25. Update root `CLAUDE.md` repository structure section to include both new plugins
+26. Verify Nx workspace graph includes both new projects (`nx graph`)
+
+### Phase 7: Quality Checks
+
+27. Run `npx nx format:write --uncommitted`
+28. Run `npx nx affected --target=lint --base=HEAD~1`
+29. Run `npm run docs:lint` (Vale)
+30. Run pre-commit hooks to verify all pass
+
+## Verification Checklist
+
+- [ ] `uniswap-viem` plugin validates (`node scripts/validate-plugin.cjs`)
+- [ ] `uniswap-trading` plugin validates (`node scripts/validate-plugin.cjs`)
+- [ ] Both plugins appear in marketplace.json
+- [ ] Both plugins appear in Nx project graph (`nx graph`)
+- [ ] Markdown linting passes for both plugins
+- [ ] No references to `ai-toolkit` remain in any migrated files
+- [ ] SKILL.md symlinks work correctly
+- [ ] Cross-references between plugins use textual recommendations (not broken relative paths)
+- [ ] Broken links to `./trading-api.md` and `./universal-router.md` removed from swap-integration.md
+- [ ] `viem-integration.md` internal refs updated for `references/` subdirectory
+- [ ] Skill frontmatter includes `name:` field
+- [ ] Eval suite scaffolds exist for both skills
+- [ ] Root `CLAUDE.md` repository structure updated
+- [ ] `npm install` succeeds with workspace changes
+- [ ] Pre-commit hooks pass (format, lint, eval-coverage)
+
+## Open Questions for Q
+
+1. **Plugin naming**: Is `uniswap-viem` the right name? Alternatives: `evm-viem`, `uniswap-evm`, `viem-wagmi`
+2. **Swap plugin naming**: Plan recommends `uniswap-trading` (per domain expert review). Alternatives: `uniswap-swaps`, or keep `uniswap-builder` if brand recognition matters
+3. **Eval priority**: Should eval suites be fully developed in this PR, or scaffolded and completed in a follow-up?
+
+## Follow-Up Tasks (Not in Scope for This PR)
+
+Identified during domain expert review:
+
+1. **Verify/update Universal Router contract addresses** -- Source references V1 address; V2 and V4-compatible routers now exist
+2. **Replace ethers usage in backend example** -- swap-integration backend example uses ethers instead of viem; should be consistent
+3. **Add UniswapX / Dutch auction details** -- Currently only a table entry; could use a brief section
+4. **Expand supported chains list** -- Missing Zora, World Chain, and other recently added chains
+5. **Develop full eval suites** -- Populate eval test cases and rubrics for both skills
+
+## Risk Assessment
+
+| Risk                                        | Likelihood | Impact | Mitigation                                                                  |
+| ------------------------------------------- | ---------- | ------ | --------------------------------------------------------------------------- |
+| Broken internal refs in viem-integration.md | High       | Medium | Explicitly update all `./[file].md` to `./references/[file].md`             |
+| Broken cross-references between plugins     | Medium     | Low    | Search for all relative paths, update to textual references                 |
+| Dead links in swap-integration.md source    | Known      | Low    | Remove links to non-existent `./trading-api.md` and `./universal-router.md` |
+| Missing files during copy                   | Low        | Medium | Verify file count matches source after migration                            |
+| Marketplace validation failure              | Low        | Low    | Run validate-plugin.cjs before committing                                   |
+| Eval coverage CI failure                    | High       | Medium | Create eval scaffolds (even if minimal) to pass coverage checks             |
+| Markdownlint failures on source content     | Medium     | Low    | Run pre-flight markdownlint check on source files                           |
+| Symlink issues on Windows                   | Low        | Low    | Test SKILL.md symlinks; fallback to copies if needed                        |
+
+## Estimated Scope
+
+- **Files to create**: ~14 new config/doc files
+- **Files to copy**: ~12 markdown files (skills, agents, references)
+- **Files to modify**: 4 (marketplace.json, cross-references in 3 skill/agent files)
+- **Complexity**: Low -- pure file operations, no code changes

--- a/evals/suites/swap-integration/cases/basic.md
+++ b/evals/suites/swap-integration/cases/basic.md
@@ -1,0 +1,30 @@
+# Basic Swap Integration Test Case
+
+Build a complete swap integration using the Uniswap Trading API.
+
+## Context
+
+- TypeScript/Node.js backend script
+- Need to swap USDC to ETH on Ethereum mainnet
+- Using the Uniswap Trading API (not SDK)
+- Have a private key for signing
+
+## Requirements
+
+1. Check token approval status via /check_approval endpoint
+2. Get a quote via /quote endpoint with proper parameters
+3. Execute the swap via /swap endpoint with correct request body format
+4. Handle Permit2 fields correctly (strip null permitData)
+5. Validate swap response before broadcasting
+
+## Constraints
+
+- Must use the Uniswap Trading API (https://trade-api.gateway.uniswap.org/v1)
+- Must handle the 3-step flow: check_approval -> quote -> swap
+- Must strip null permitData fields from the swap request
+- Must validate swap.data is non-empty before broadcasting
+- Should include error handling for API failures
+
+## Expected Output
+
+A working TypeScript implementation that demonstrates the complete Trading API swap flow with proper null field handling, Permit2 rules, and pre-broadcast validation.

--- a/evals/suites/swap-integration/promptfoo.yaml
+++ b/evals/suites/swap-integration/promptfoo.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'swap-integration Skill Evaluation'
+
+# Prompts (eval cases)
+prompts:
+  - file://cases/basic.md
+
+# Provider configuration
+providers:
+  - id: anthropic:claude-sonnet-4-5-20250929
+    config:
+      temperature: 0
+      max_tokens: 8192 # Swap integrations need more tokens for complete examples
+
+# Default test configuration applied to all tests
+defaultTest:
+  options:
+    timeout: 120000 # 2 minutes per case
+
+# Test cases with specific assertions
+tests:
+  - vars:
+      scenario: basic-trading-api-swap
+    assert:
+      # Correctness rubric
+      - type: llm-rubric
+        value: file://rubrics/correctness.txt
+        threshold: 0.8
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Completeness rubric
+      - type: llm-rubric
+        value: file://rubrics/completeness.txt
+        threshold: 0.85
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Deterministic checks for required patterns
+      - type: contains
+        value: 'trade-api.gateway.uniswap.org'
+      - type: contains
+        value: 'check_approval'
+      - type: contains
+        value: '/quote'
+      - type: contains
+        value: '/swap'

--- a/evals/suites/swap-integration/rubrics/completeness.txt
+++ b/evals/suites/swap-integration/rubrics/completeness.txt
@@ -1,0 +1,56 @@
+# Completeness Rubric for swap-integration
+
+Evaluate whether the generated output includes all expected elements for a Uniswap swap integration.
+
+## Expected Elements (Should Include)
+
+Score based on how many of these are present:
+
+1. **Documentation**
+   - Comments explaining the 3-step Trading API flow
+   - Notes about common pitfalls (null permitData, request body format)
+
+2. **Error Handling**
+   - Handles API errors with status code checking
+   - Validates swap response before broadcasting
+   - Handles token approval failures
+
+3. **Best Practices**
+   - Strips null fields from quote response before swap request
+   - Validates swap.data is non-empty hex
+   - Checks both permitData and signature are present/absent together
+   - Uses typed request/response interfaces
+
+4. **Maintainability**
+   - Code is organized into clear helper functions
+   - API URL and configuration are extracted as constants
+   - Logic flow follows the check_approval -> quote -> swap pattern
+
+5. **Completeness**
+   - Includes all necessary imports
+   - Covers the full swap lifecycle
+   - Handles both Permit2 and non-Permit2 flows
+
+## Penalties (Should Not Include)
+
+Deduct points for:
+- Wrapping quote in {quote: quoteResponse} (-0.15)
+- Including permitData: null in swap request (-0.15)
+- Missing pre-broadcast validation (-0.1)
+- Hardcoding API keys in code (-0.1)
+
+## Scoring Guide
+
+Base score from expected elements:
+- 5/5 elements: 1.0
+- 4/5 elements: 0.85
+- 3/5 elements: 0.65
+- 2/5 elements: 0.5
+- 1/5 elements: 0.3
+- 0/5 elements: 0.0
+
+Then subtract any penalties.
+
+## Instructions
+
+Count the expected elements present, then apply any penalties for issues found. Provide the final score.

--- a/evals/suites/swap-integration/rubrics/correctness.txt
+++ b/evals/suites/swap-integration/rubrics/correctness.txt
@@ -1,0 +1,45 @@
+# Correctness Rubric for swap-integration
+
+Evaluate whether the generated output correctly implements Uniswap swap integration.
+
+## Required Elements (Must Include)
+
+Score based on how many of these are correctly implemented:
+
+1. **Trading API Flow**
+   - Uses correct base URL (https://trade-api.gateway.uniswap.org/v1)
+   - Implements 3-step flow: check_approval -> quote -> swap
+   - Includes x-api-key header
+
+2. **Request Body Format**
+   - Quote response is spread into swap request (not wrapped in {quote: ...})
+   - Null permitData fields are stripped before sending
+   - Permit2 signature and permitData are both present or both absent
+
+3. **Response Validation**
+   - Validates swap.data is non-empty hex before broadcasting
+   - Validates addresses in response
+   - Checks quote freshness considerations
+
+4. **Token Handling**
+   - Handles ERC-20 approval flow
+   - Distinguishes native ETH from ERC-20 tokens
+   - Uses correct amount formatting
+
+5. **Error Handling**
+   - Handles API error responses (400, 401, 404, 429, 500)
+   - Provides meaningful error messages
+   - Includes retry logic or backoff for transient failures
+
+## Scoring Guide
+
+- 5/5 elements correct: 1.0
+- 4/5 elements correct: 0.8
+- 3/5 elements correct: 0.6
+- 2/5 elements correct: 0.4
+- 1/5 elements correct: 0.2
+- 0/5 elements correct: 0.0
+
+## Instructions
+
+Count how many of the required elements are correctly implemented and provide the corresponding score.

--- a/evals/suites/viem-integration/cases/basic.md
+++ b/evals/suites/viem-integration/cases/basic.md
@@ -1,0 +1,27 @@
+# Basic viem Integration Test Case
+
+Set up a viem client to read data from the Ethereum blockchain.
+
+## Context
+
+- TypeScript/Node.js backend application
+- Needs to read ERC-20 token balances
+- Using viem as the blockchain library
+
+## Requirements
+
+1. Create a PublicClient with http transport for Ethereum mainnet
+2. Read an ERC-20 token balance using readContract
+3. Format the balance with correct decimals
+4. Include proper TypeScript types
+5. Handle potential errors
+
+## Constraints
+
+- Must use viem (not ethers.js or web3.js)
+- Must use TypeScript with proper typing
+- Should follow viem best practices
+
+## Expected Output
+
+A working TypeScript code example that creates a viem PublicClient, reads a token balance, and formats it correctly.

--- a/evals/suites/viem-integration/promptfoo.yaml
+++ b/evals/suites/viem-integration/promptfoo.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+description: 'viem-integration Skill Evaluation'
+
+# Prompts (eval cases)
+prompts:
+  - file://cases/basic.md
+
+# Provider configuration
+providers:
+  - id: anthropic:claude-sonnet-4-5-20250929
+    config:
+      temperature: 0
+
+# Default test configuration applied to all tests
+defaultTest:
+  options:
+    timeout: 120000 # 2 minutes per case
+
+# Test cases with specific assertions
+tests:
+  - vars:
+      scenario: basic-viem-setup
+    assert:
+      # Correctness rubric
+      - type: llm-rubric
+        value: file://rubrics/correctness.txt
+        threshold: 0.8
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Completeness rubric
+      - type: llm-rubric
+        value: file://rubrics/completeness.txt
+        threshold: 0.85
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Deterministic checks for required patterns
+      - type: contains
+        value: 'createPublicClient'
+      - type: contains
+        value: 'viem'

--- a/evals/suites/viem-integration/rubrics/completeness.txt
+++ b/evals/suites/viem-integration/rubrics/completeness.txt
@@ -1,0 +1,51 @@
+# Completeness Rubric for viem-integration
+
+Evaluate whether the generated output includes all expected elements and follows viem best practices.
+
+## Expected Elements (Should Include)
+
+Score based on how many of these are present:
+
+1. **Documentation**
+   - Has inline comments explaining key steps
+   - Includes package installation instructions if applicable
+
+2. **Error Handling**
+   - Handles RPC errors gracefully
+   - Handles contract revert cases
+
+3. **Best Practices**
+   - Uses simulateContract before writeContract
+   - Uses parseAbi or typed ABIs instead of raw ABI arrays
+   - Uses chain constants from viem/chains
+
+4. **Maintainability**
+   - Code is readable and well-structured
+   - Variables are descriptively named
+
+5. **Completeness**
+   - Includes all necessary imports
+   - Example is runnable without modification (except env vars)
+
+## Penalties (Should Not Include)
+
+Deduct points for:
+- Using deprecated viem APIs (-0.1)
+- Hardcoding private keys in code (-0.15)
+- Missing await on async operations (-0.1)
+
+## Scoring Guide
+
+Base score from expected elements:
+- 5/5 elements: 1.0
+- 4/5 elements: 0.85
+- 3/5 elements: 0.65
+- 2/5 elements: 0.5
+- 1/5 elements: 0.3
+- 0/5 elements: 0.0
+
+Then subtract any penalties.
+
+## Instructions
+
+Count the expected elements present, then apply any penalties for issues found. Provide the final score.

--- a/evals/suites/viem-integration/rubrics/correctness.txt
+++ b/evals/suites/viem-integration/rubrics/correctness.txt
@@ -1,0 +1,41 @@
+# Correctness Rubric for viem-integration
+
+Evaluate whether the generated output correctly implements viem blockchain interactions.
+
+## Required Elements (Must Include)
+
+Score based on how many of these are correctly implemented:
+
+1. **Client Setup**
+   - Uses createPublicClient with correct chain and transport
+   - Imports from 'viem' and 'viem/chains'
+
+2. **Contract Read**
+   - Uses readContract with correct ABI, address, and function name
+   - Passes arguments correctly
+
+3. **Type Safety**
+   - Uses TypeScript types correctly
+   - No use of 'any' type
+   - Proper hex string types for addresses
+
+4. **Value Formatting**
+   - Uses formatUnits or formatEther for human-readable output
+   - Handles BigInt values correctly
+
+5. **Error Handling**
+   - Includes try-catch or .catch() for async operations
+   - Provides meaningful error messages
+
+## Scoring Guide
+
+- 5/5 elements correct: 1.0
+- 4/5 elements correct: 0.8
+- 3/5 elements correct: 0.6
+- 2/5 elements correct: 0.4
+- 1/5 elements correct: 0.2
+- 0/5 elements correct: 0.0
+
+## Instructions
+
+Count how many of the required elements are correctly implemented and provide the corresponding score.


### PR DESCRIPTION
Add eval suite scaffolds for viem-integration and swap-integration
skills with basic test cases and rubrics. Update root CLAUDE.md
repository structure to include both new plugins.

- viem-integration eval: basic client setup + contract read test case
- swap-integration eval: Trading API 3-step flow test case
- Correctness and completeness rubrics for both
- Root CLAUDE.md updated with uniswap-viem and uniswap-trading
- Migration plan document for ECO-81

Part of ECO-81: Move uniswap-builder plugin to uniswap-ai repository

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Add eval suite scaffolds for the new `viem-integration` and `swap-integration` skills with basic test cases and rubrics. Update root `CLAUDE.md` repository structure to include both new plugins (`uniswap-viem` and `uniswap-trading`).
## Changes
### Eval Suite Scaffolds
| Suite | Test Cases | Rubrics | Focus |
|-------|------------|---------|-------|
| `viem-integration` | 1 (basic client setup + contract read) | 2 (correctness, completeness) | PublicClient creation, ERC-20 balance reading |
| `swap-integration` | 1 (Trading API 3-step flow) | 2 (correctness, completeness) | check_approval → quote → swap lifecycle |
### Eval Suite Details
**viem-integration**:
- Basic test case covering PublicClient setup with http transport
- Correctness rubric validating proper viem usage patterns
- Completeness rubric checking for error handling and best practices
**swap-integration**:
- Basic test case covering Uniswap Trading API swap flow
- Correctness rubric validating 3-step API flow and request body format
- Completeness rubric checking for Permit2 handling and pre-broadcast validation
- Deterministic assertions for required API endpoints
### Documentation Updates
- `CLAUDE.md` repository structure updated to include:
  - `uniswap-viem/` - EVM blockchain integration (viem/wagmi)
  - `uniswap-trading/` - Uniswap swap integration
### Migration Plan
- Added `docs/plans/eco-81-migration-plan.md` documenting the migration strategy for splitting the original `uniswap-trading` plugin into two focused plugins
## Notes
- Eval scaffolds provide basic coverage to pass CI eval-coverage checks
- Full eval test cases and rubrics can be expanded in follow-up work
- Both eval suites use `claude-sonnet-4-5-20250929` as the provider with 2-minute timeout per case
Part of ECO-81: Move uniswap-builder plugin to uniswap-ai repository
## Test plan
- [ ] `nx run evals:eval --suite=viem-integration` runs without errors
- [ ] `nx run evals:eval --suite=swap-integration` runs without errors
- [ ] Eval coverage CI check passes with new scaffolds
<!-- claude-pr-description-end -->