### PR TITLE
feat(plugins): expand swap-integration with V4 addresses, chains, UniswapX, and viem

### DIFF
--- a/evals/suites/swap-integration/cases/eth-to-token-swap.md
+++ b/evals/suites/swap-integration/cases/eth-to-token-swap.md
@@ -1,0 +1,38 @@
+# ETH-to-Token Swap Test Case
+
+Build a swap integration that handles native ETH as the input token, including the ETH wrapping step.
+
+## Context
+
+- TypeScript/Node.js backend script
+- Need to swap native ETH to USDC on Ethereum mainnet
+- Using the Uniswap Trading API
+- Have a private key for signing
+
+## Requirements
+
+1. Detect that the input token is native ETH (address 0x0000000000000000000000000000000000000000 or similar sentinel)
+2. Skip the /check_approval step for native ETH (no approval needed for native tokens)
+3. Get a quote via /quote with the ETH sentinel address as tokenIn
+4. Handle the swap response value field correctly (must send ETH value with the transaction)
+5. Strip null permitData fields from the swap request before sending
+6. Validate swap.data is non-empty before broadcasting
+7. Set the transaction value to the ETH amount being swapped (not "0")
+
+## Constraints
+
+- Must use the Uniswap Trading API (https://trade-api.gateway.uniswap.org/v1)
+- Must correctly distinguish native ETH from ERC-20 token flows
+- Must handle the value field in the swap response (ETH swaps require msg.value)
+- Must not call /check_approval for native ETH inputs
+- Should include error handling for API failures and transaction reverts
+
+## Edge Cases to Handle
+
+- The swap response value field will be non-zero for ETH inputs
+- The quote response may still contain permitData: null even for ETH swaps
+- Gas estimation should account for the ETH value being sent
+
+## Expected Output
+
+A working TypeScript implementation that demonstrates swapping native ETH to an ERC-20 token via the Trading API, correctly handling the ETH-specific flow (skipping approval, passing transaction value, stripping null fields).

--- a/evals/suites/swap-integration/cases/security-pitfalls.md
+++ b/evals/suites/swap-integration/cases/security-pitfalls.md
@@ -1,0 +1,49 @@
+# Security Pitfalls Test Case
+
+Build a secure swap integration that avoids all common Trading API pitfalls and includes defensive validation.
+
+## Context
+
+- TypeScript/Node.js backend script handling real user funds
+- Production environment where security is critical
+- Using the Uniswap Trading API
+- Must handle both Permit2 and non-Permit2 swap flows
+
+## Requirements
+
+1. Strip null permitData from the quote response before sending to /swap (API rejects permitData: null)
+2. Never wrap the quote response in {quote: quoteResponse} - spread it into the request body
+3. Validate that permitData and signature are BOTH present or BOTH absent (never one without the other)
+4. Validate swap.data is non-empty hex before broadcasting (check for empty string, "0x", null, undefined)
+5. Validate swap.to and swap.from are valid Ethereum addresses before broadcasting
+6. Handle quote expiration by checking freshness and re-fetching if stale
+7. Include a prepareSwapRequest helper that strips null fields and enforces Permit2 invariants
+8. Include a validateSwapResponse function that checks all pre-broadcast conditions
+
+## Constraints
+
+- Must demonstrate the null field stripping pattern (destructure permitData, permitTransaction, spread rest)
+- Must NOT include permitData: null in the swap request body
+- Must NOT wrap quote in {quote: ...}
+- Must validate swap response fields before calling sendTransaction
+- Must handle both Permit2 and non-Permit2 flows correctly
+
+## Security Checks the Output MUST Include
+
+- Pre-broadcast validation of swap.data (non-empty, valid hex)
+- Address validation of swap.to and swap.from
+- Permit2 field pairing (both or neither)
+- Null field stripping from quote response
+- Quote freshness check or deadline parameter
+
+## Anti-Patterns the Output MUST NOT Include
+
+- permitData: null in any request body
+- {quote: quoteResponse} wrapping pattern
+- Broadcasting without validating swap.data
+- Including signature without permitData or vice versa
+- Hardcoded API keys in source code
+
+## Expected Output
+
+A production-quality TypeScript implementation with explicit prepareSwapRequest and validateSwapResponse helper functions that demonstrate all critical security patterns for the Uniswap Trading API.

--- a/evals/suites/swap-integration/promptfoo.yaml
+++ b/evals/suites/swap-integration/promptfoo.yaml
@@ -4,6 +4,8 @@ description: 'swap-integration Skill Evaluation'
 # Prompts (eval cases)
 prompts:
   - file://cases/basic.md
+  - file://cases/eth-to-token-swap.md
+  - file://cases/security-pitfalls.md
 
 # Provider configuration
 providers:
@@ -43,3 +45,69 @@ tests:
         value: '/quote'
       - type: contains
         value: '/swap'
+
+  - vars:
+      scenario: eth-to-token-swap
+    assert:
+      # Correctness rubric
+      - type: llm-rubric
+        value: file://rubrics/correctness.txt
+        threshold: 0.8
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Completeness rubric
+      - type: llm-rubric
+        value: file://rubrics/completeness.txt
+        threshold: 0.85
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Deterministic checks for ETH-specific patterns
+      - type: contains
+        value: 'trade-api.gateway.uniswap.org'
+      - type: contains
+        value: '/quote'
+      - type: contains
+        value: '/swap'
+      - type: contains
+        value: 'value'
+      - type: contains
+        value: 'permitData'
+
+      # Should not wrap quote in {quote: ...}
+      - type: not-contains
+        value: 'quote: quoteResponse'
+
+  - vars:
+      scenario: security-pitfalls
+    assert:
+      # Correctness rubric
+      - type: llm-rubric
+        value: file://rubrics/correctness.txt
+        threshold: 0.8
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Completeness rubric
+      - type: llm-rubric
+        value: file://rubrics/completeness.txt
+        threshold: 0.85
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Must include validation patterns
+      - type: contains
+        value: 'swap.data'
+      - type: contains
+        value: 'permitData'
+      - type: contains
+        value: 'signature'
+      - type: contains
+        value: 'isAddress'
+
+      # Must strip null fields (destructuring pattern)
+      - type: contains
+        value: 'permitTransaction'
+
+      # Must not include anti-patterns
+      - type: not-contains
+        value: 'permitData: null'
+      - type: not-contains
+        value: 'quote: quoteResponse'

--- a/evals/suites/viem-integration/cases/wagmi-react.md
+++ b/evals/suites/viem-integration/cases/wagmi-react.md
@@ -1,0 +1,31 @@
+# Wagmi React Hook Setup Test Case
+
+Set up a React application with wagmi hooks for wallet connection and token balance display.
+
+## Context
+
+- React/Next.js frontend application
+- Need to connect browser wallets (MetaMask, WalletConnect, Coinbase Wallet)
+- Display connected account's ERC-20 token balance (USDC)
+- Support multiple chains (Ethereum mainnet, Arbitrum, Base)
+
+## Requirements
+
+1. Create a wagmi config with createConfig, multiple chains, and connectors (injected, walletConnect, coinbaseWallet)
+2. Set up WagmiProvider and QueryClientProvider in the app root
+3. Build a wallet connection component using useAccount and useConnect hooks
+4. Read an ERC-20 token balance using useReadContract with a parsed ABI
+5. Display loading, error, and success states correctly
+6. Include TypeScript types (Register interface for wagmi config)
+
+## Constraints
+
+- Must use wagmi (not raw viem) for React hooks
+- Must use @tanstack/react-query as a peer dependency
+- Must import chains from 'wagmi/chains' and connectors from 'wagmi/connectors'
+- Must handle wallet connection states (connecting, connected, disconnected)
+- Should follow wagmi best practices for loading and error states
+
+## Expected Output
+
+A working React/TypeScript code example that configures wagmi with multiple chains and connectors, wraps the app in the required providers, connects a wallet, and reads a token balance using wagmi hooks.

--- a/evals/suites/viem-integration/promptfoo.yaml
+++ b/evals/suites/viem-integration/promptfoo.yaml
@@ -4,6 +4,7 @@ description: 'viem-integration Skill Evaluation'
 # Prompts (eval cases)
 prompts:
   - file://cases/basic.md
+  - file://cases/wagmi-react.md
 
 # Provider configuration
 providers:
@@ -38,3 +39,36 @@ tests:
         value: 'createPublicClient'
       - type: contains
         value: 'viem'
+
+  - vars:
+      scenario: wagmi-react-setup
+    assert:
+      # Correctness rubric
+      - type: llm-rubric
+        value: file://rubrics/correctness.txt
+        threshold: 0.8
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Completeness rubric
+      - type: llm-rubric
+        value: file://rubrics/completeness.txt
+        threshold: 0.85
+        provider: anthropic:claude-sonnet-4-5-20250929
+
+      # Deterministic checks for wagmi-specific patterns
+      - type: contains
+        value: 'WagmiProvider'
+      - type: contains
+        value: 'createConfig'
+      - type: contains
+        value: 'useAccount'
+      - type: contains
+        value: 'useConnect'
+      - type: contains
+        value: 'QueryClientProvider'
+      - type: contains
+        value: 'wagmi'
+
+      # Should not contain common mistakes
+      - type: not-contains
+        value: 'ethers'

--- a/packages/plugins/uniswap-trading/CLAUDE.md
+++ b/packages/plugins/uniswap-trading/CLAUDE.md
@@ -52,7 +52,7 @@ uniswap-trading/
 
 ## Supported Chains
 
-Mainnet (1), Optimism (10), Polygon (137), Arbitrum (42161), Base (8453), BNB (56), Blast (81457), Unichain (130)
+Ethereum (1), Optimism (10), BNB (56), Unichain (130), Polygon (137), X Layer (196), zkSync (324), World Chain (480), Soneium (1868), Base (8453), Arbitrum (42161), Celo (42220), Avalanche (43114), Blast (81457), Zora (7777777), Monad (143)
 
 ## Related Plugins
 


### PR DESCRIPTION
- Update Universal Router addresses from single V1 to per-chain V4 (15 chains)
- Expand supported chains from 8 to 16 (add Zora, World Chain, Celo, etc.)
- Add UniswapX auction types section (Dutch, Priority, per-chain mechanics)
- Update routing types table with DUTCH_V3, PRIORITY, LIMIT_ORDER, etc.
- Rewrite backend example from ethers to viem
- Replace ethers with viem in Permit2 integration code
- Add eval cases: eth-to-token-swap, security-pitfalls, wagmi-react

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Expand the swap-integration skill with updated V4 Universal Router addresses, additional chain support, UniswapX auction documentation, and modern viem-based code examples.
## Changes
### Skill Content Updates
| Area | Before | After |
| --- | --- | --- |
| Supported chains | 8 chains | 16 chains (+Zora, World Chain, Celo, Avalanche, Soneium, X Layer, zkSync, Monad) |
| Universal Router | Single V1 address | Per-chain V4 addresses (15 chains) |
| Routing types | 5 types (CLASSIC, DUTCH_V2, WRAP, UNWRAP, BRIDGE) | 10 types (+DUTCH_V3, PRIORITY, DUTCH_LIMIT, LIMIT_ORDER, QUICKROUTE) |
| Backend example | ethers.js | viem with proper typing |
| Permit2 code | ethers-based | viem with publicClient/walletClient |
### New UniswapX Auction Types Section
- **Exclusive Dutch Auction** (Ethereum) — RFQ phase with exclusive filling rights
- **Open Dutch Auction** (Arbitrum) — Direct open auction with Unimind algorithm
- **Priority Gas Auction** (Base, Unichain) — Priority fee-based competition on OP Stack
### New Eval Cases
- `swap-integration/eth-to-token-swap.md` — Native ETH as input token flow
- `swap-integration/security-pitfalls.md` — Security validation patterns (null stripping, Permit2 invariants)
- `viem-integration/wagmi-react.md` — Wagmi React hooks setup with multiple chains
## Notes
- The legacy V1 Universal Router address `0x3fC91A3afd70395Cd496C647d5a6CC9D4B2b7FAD` is marked as deprecated
- Backend code examples now use viem's `createWalletClient`/`createPublicClient` pattern with proper TypeScript types
- Eval assertions include anti-pattern checks (`not-contains` for common mistakes like `permitData: null`)
## Test plan
- [ ] Skill renders correctly in Claude Code
- [ ] `nx run evals:eval --suite=swap-integration` passes with new cases
- [ ] `nx run evals:eval --suite=viem-integration` passes with wagmi-react case
<!-- claude-pr-description-end -->