### PR TITLE
fix(swap-integration): document Trading API key acquisition

### DIFF
--- a/packages/plugins/uniswap-trading/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-trading/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-trading",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Integrate Uniswap swaps via Trading API, Universal Router SDK, or direct smart contract calls",
   "author": {
     "name": "Uniswap Labs",

--- a/packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md
@@ -48,6 +48,8 @@ Best for: Frontends, backends, scripts. Handles routing optimization automatical
 
 **Authentication**: `x-api-key: <your-api-key>` header required
 
+**Getting an API Key**: The Trading API requires an API key for authentication. Visit the [Uniswap Developer Portal](https://developer.uniswap.org/) to register and obtain your API key. Keys are typically available for immediate use after registration. Include it as an `x-api-key` header in all API requests.
+
 **3-Step Flow**:
 
 ```text


### PR DESCRIPTION
## Summary

Addresses pressure test feedback for the **swap-integration** skill from the [Openclaw Analysis Report](https://www.notion.so/Matt-Luu-Openclaw-Analysis-Uniswap-AI-tools-Full-Report-305c52b2548b8034a84dc1f1f17f6489).

- Add API key acquisition instructions with Uniswap Developer Portal link
- The report flagged that the skill references API key authentication but doesn't explain how to obtain one
- Bump `uniswap-trading` plugin version `1.2.0` → `1.2.1`

## Test Plan

- [ ] `node scripts/validate-plugin.cjs packages/plugins/uniswap-trading` passes
- [ ] Markdown lint passes

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Address pressure test feedback for the swap-integration skill by adding API key acquisition instructions.
## Changes
| File | Description |
|------|-------------|
| `packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md` | Add "Getting an API Key" section with Developer Portal link and usage instructions |
| `packages/plugins/uniswap-trading/.claude-plugin/plugin.json` | Bump version 1.2.0 → 1.2.1 |
## Notes
- The Trading API requires authentication via `x-api-key` header
- API keys are available at [developer.uniswap.org](https://developer.uniswap.org/) after registration
- This is a documentation-only change with no code modifications
<!-- claude-pr-description-end -->