### PR TITLE
fix(aggregator-hook-creator): implement _calculateDelta, add access control and tests

### DIFF
--- a/packages/plugins/uniswap-hooks/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-hooks",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "AI-powered, security-first assistance for creating Uniswap V4 hooks, including aggregator hooks, custom fee hooks, and more",
   "author": {
     "name": "Uniswap Labs",


### PR DESCRIPTION
## Summary

Addresses **critical** (P0) pressure test feedback for the **aggregator-hook-creator** skill from the [Openclaw Analysis Report](https://www.notion.so/Matt-Luu-Openclaw-Analysis-Uniswap-AI-tools-Full-Report-305c52b2548b8034a84dc1f1f17f6489).

This is the most significant fix — the `_calculateDelta()` function was a TODO placeholder, which is the skill's core functionality.

### Changes

**implementations.md (reference code):**
- Replace TODO `_calculateDelta()` with working `toBeforeSwapDelta(specifiedAmount, 0)` implementation
- Add `owner` state variable and `allowedTargets` mapping for access control
- Add `setAllowedTarget()` owner-only function
- Add target validation in `beforeSwap`: `require(allowedTargets[actions[i].to], "Target not allowed")`
- Secure `receive() external payable` with authorization check
- Fix test suite: add `ICurvePool` interface, `MockCurvePool` contract, proper imports
- Add tests: `test_noExternalRouting`, `test_volumeTracking`, `test_unauthorizedTargetReverts`

**SKILL.md:**
- Add ASCII token flow diagram showing User → Router → PoolManager → Hook → External DEX flow

- Bump `uniswap-hooks` plugin version `1.3.0` → `1.4.0`

## Test Plan

- [ ] `node scripts/validate-plugin.cjs packages/plugins/uniswap-hooks` passes
- [ ] Markdown lint passes
- [ ] Code examples compile conceptually (Solidity reference code)

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Address critical pressure test feedback for the aggregator-hook-creator skill by implementing the previously stubbed `_calculateDelta()` function, adding access control for external call targets, and expanding test coverage.
## Changes
### Implementation Fixes
| File | Description |
|------|-------------|
| `references/implementations.md` | Replace TODO `_calculateDelta()` with working `toBeforeSwapDelta()` implementation that correctly handles EXACT_INPUT/EXACT_OUTPUT swap types |
| `references/implementations.md` | Add `owner` state variable and `allowedTargets` mapping for access control |
| `references/implementations.md` | Add `setAllowedTarget()` owner-only function for managing approved external DEX targets |
| `references/implementations.md` | Secure `receive()` function with authorization check (owner or allowed targets only) |
| `references/implementations.md` | Add target validation in `beforeSwap()` to prevent calls to unauthorized contracts |
### Documentation
| File | Description |
|------|-------------|
| `SKILL.md` | Add ASCII token flow diagram showing User→Router→PoolManager→Hook→DEX→User flow |
### Test Suite
| File | Description |
|------|-------------|
| `references/implementations.md` | Add `ICurvePool` interface and `MockCurvePool` contract for proper test isolation |
| `references/implementations.md` | Fix imports: add `ExternalAction` struct import |
| `references/implementations.md` | Add `test_noExternalRouting()` — verifies V4 pool is used when no hookData provided |
| `references/implementations.md` | Update `test_volumeTracking()` — now properly tests external routing with mock Curve pool |
| `references/implementations.md` | Add `test_unauthorizedTargetReverts()` — verifies access control prevents unauthorized targets |
### Versioning
- Bump uniswap-hooks plugin version 1.3.0 → 1.4.0
## Notes
### Security Improvements
The access control additions address a critical security gap where the previous implementation allowed arbitrary external calls to any address. Now:
1. Only whitelisted targets can be called via `beforeSwap()`
2. ETH transfers via `receive()` are restricted to owner and allowed targets
3. Owner can manage the allowlist via `setAllowedTarget()`
### `_calculateDelta()` Implementation
The function now correctly:
- Uses `toBeforeSwapDelta()` from v4-core to construct the return value
- Handles both EXACT_INPUT (negative amountSpecified) and EXACT_OUTPUT (positive amountSpecified)
- Returns a delta that tells PoolManager "the hook handled this swap"
## Test Plan
- [ ] `nx run evals:eval --suite=aggregator-hook-creator` passes with ≥85% rate
- [ ] All three new test cases compile and pass conceptually
- [ ] Access control logic is verified via `test_unauthorizedTargetReverts`
<!-- claude-pr-description-end -->