### PR TITLE
fix(ci): add id-token permission for Claude reusable workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -189,8 +189,9 @@ jobs:
     needs: check-automated
     permissions:
       contents: read
-      pull-requests: write
+      id-token: write
       issues: write
+      pull-requests: write
     if: |
       github.event_name == 'pull_request' &&
       (
@@ -246,8 +247,9 @@ jobs:
     needs: get-pr-info
     permissions:
       contents: read
-      pull-requests: write
+      id-token: write
       issues: write
+      pull-requests: write
     if: |
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
@@ -276,8 +278,9 @@ jobs:
     needs: get-pr-info
     permissions:
       contents: read
-      pull-requests: write
+      id-token: write
       issues: write
+      pull-requests: write
     if: |
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -32,6 +32,7 @@ jobs:
   generate-metadata:
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     # Skip conditions:
     # - Merge queue PRs (handled separately)


### PR DESCRIPTION
## Summary

- Adds `id-token: write` to job-level permissions in `generate-pr-title-description.yml` and `claude-code-review.yml`
- The zizmor security hardening in #37 added `permissions: {}` at the workflow level (all permissions → `none`), but the job-level permissions were missing `id-token: write` which the ai-toolkit reusable workflows require for OIDC authentication with the Claude Code Action
- This caused `startup_failure` on PR #49 and would affect all future PRs

## Test plan

- [ ] Verify the "Generate PR Title & Description" workflow succeeds on this PR
- [ ] Verify the "Claude Code Review" workflow succeeds on this PR