### PR TITLE
fix(ci): handle fork PRs with fallback defaults and skip conditions

### DIFF
--- a/.github/workflows/ci-pr-checks.yml
+++ b/.github/workflows/ci-pr-checks.yml
@@ -64,12 +64,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
           cache: 'npm'
 
       - name: Install npm
         env:
-          NPM_VERSION: ${{ vars.NPM_VERSION }}
+          NPM_VERSION: ${{ vars.NPM_VERSION || '11.7.0' }}
         # nosemgrep: uniswap.npm-package-in-action-not-pinned-to-commit-sha -- npm CLI from npm registry, not a git-hosted action
         run: npm install -g "npm@$NPM_VERSION"
 
@@ -150,7 +150,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
 
       - name: Validate all plugins
         uses: ./.github/actions/validate-plugins
@@ -177,7 +177,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
 
       - name: Validate skills
         uses: ./.github/actions/validate-skills
@@ -201,7 +201,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
 
       - name: Validate documentation pages
         uses: ./.github/actions/validate-docs

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -193,8 +193,10 @@ jobs:
       id-token: write
       issues: write
       pull-requests: write
+    # Skip fork PRs (no secrets available)
     if: |
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       (
         needs.check-automated.outputs.is_automated != 'true' ||
         needs.check-automated.outputs.category == 'deps'

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -46,10 +46,12 @@ concurrency:
 
 jobs:
   docs-check:
-    # Skip if PR is from a bot (e.g., dependabot)
+    # Skip if PR is from a bot (e.g., dependabot) or a fork (no secrets available)
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && !contains(github.event.pull_request.user.login, '[bot]'))
+      (github.event_name == 'pull_request' &&
+       !contains(github.event.pull_request.user.login, '[bot]') &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@40b7cda9c5816be0587e47734fc450447c5aaeba # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -67,12 +67,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
           cache: 'npm'
 
       - name: Install npm
         env:
-          NPM_VERSION: ${{ vars.NPM_VERSION }}
+          NPM_VERSION: ${{ vars.NPM_VERSION || '11.7.0' }}
         # NPM_VERSION is a repository variable controlled by admins
         # Safe to use because: (1) admin-controlled (2) validated by npm version parser
         run: npm install -g "npm@$NPM_VERSION" # nosemgrep: uniswap.npm-package-in-action-not-pinned-to-commit-sha

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -37,12 +37,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
-          node-version: ${{ vars.NODE_VERSION }}
+          node-version: ${{ vars.NODE_VERSION || '22' }}
           cache: 'npm'
 
       - name: Install npm
         env:
-          NPM_VERSION: ${{ vars.NPM_VERSION }}
+          NPM_VERSION: ${{ vars.NPM_VERSION || '11.7.0' }}
         run: npm install -g "npm@$NPM_VERSION" # nosemgrep: uniswap.npm-package-in-action-not-pinned-to-commit-sha
 
       - name: Install dependencies

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -35,11 +35,13 @@ jobs:
       id-token: write
       pull-requests: write
     # Skip conditions:
+    # - Fork PRs (no secrets available)
     # - Merge queue PRs (handled separately)
     # - Dependabot PRs (already have proper titles)
     # - Release PRs (have their own format)
     # - Production promotion PRs (have their own format)
     if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
       !contains(github.head_ref, 'gh-readonly-queue/') &&
       !contains(github.head_ref, 'dependabot/') &&
       !contains(github.head_ref, 'release/') &&


### PR DESCRIPTION
## Summary
- Add fallback defaults for `vars.NODE_VERSION` (`'22'`) and `vars.NPM_VERSION` (`'11.7.0'`) since repository variables are unavailable for fork PRs
- Skip secret-dependent workflows (docs-check, generate-metadata, code-review) for fork PRs via `github.event.pull_request.head.repo.full_name == github.repository` check

## Context
Fork PR #55 fails all CI checks because:
1. `vars.NPM_VERSION` resolves to empty → `npm install -g "npm@"` fails
2. `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` unavailable → auth validation fails in docs-check and generate-metadata workflows

## Changes
| Workflow | Fix |
|----------|-----|
| `ci-pr-checks.yml` | Fallback defaults for `NODE_VERSION` and `NPM_VERSION` (5 occurrences) |
| `evals.yml` | Fallback defaults for `NODE_VERSION` and `NPM_VERSION` |
| `generate-docs.yml` | Fallback defaults for `NODE_VERSION` and `NPM_VERSION` |
| `claude-docs-check.yml` | Skip for fork PRs (no secrets) |
| `generate-pr-title-description.yml` | Skip for fork PRs (no secrets) |
| `claude-code-review.yml` | Skip auto-review for fork PRs (no secrets) |

## Test plan
- [ ] Verify PR 55 CI passes after this is merged and CI is re-run
- [ ] Verify non-fork PRs still run all workflows normally (vars take precedence over defaults)