### PR TITLE
ci: update zizmor scan to disable advanced security

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,9 +2,9 @@ name: GitHub Actions Security Analysis with zizmor
 
 on:
   push:
-    branches: ['main']
+    branches: ["main"]
   pull_request:
-    branches: ['**']
+    branches: ["**"]
 
 permissions: {}
 
@@ -13,16 +13,16 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
       actions: read
     steps:
-      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-
       - name: Checkout repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary
- Update the existing zizmor workflow to disable advanced security (SARIF upload)
- Use inline PR annotations instead, removing the need for `security-events: write` permission
- Pin actions to SHA with version comments

Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Update the zizmor GitHub Actions security analysis workflow to use inline PR annotations instead of SARIF upload, simplifying permissions and improving developer experience.
## Changes
| File | Description |
|------|-------------|
| `.github/workflows/zizmor.yml` | Remove `security-events: write` permission (no longer needed) |
| `.github/workflows/zizmor.yml` | Remove bullfrog step (unnecessary for this workflow) |
| `.github/workflows/zizmor.yml` | Update checkout action v5.0.0 → v6.0.2 |
| `.github/workflows/zizmor.yml` | Configure zizmor-action with `advanced-security: false` and `annotations: true` |
| `.github/workflows/zizmor.yml` | Normalize quote style (single → double quotes) |
## Notes
- **SARIF disabled**: The workflow no longer uploads results to GitHub Advanced Security, which required the `security-events: write` permission
- **Inline annotations**: Security findings now appear as inline PR annotations, providing immediate feedback without requiring Advanced Security features
- **Simplified permissions**: Only `contents: read` and `actions: read` are now required
- **Bullfrog removed**: The bullfrog security step was removed as it's not required for static workflow analysis
<!-- claude-pr-description-end -->