### PR TITLE
fix(uniswap-hooks): add gas budget guidance for hook callbacks

### DIFF
--- a/packages/plugins/uniswap-hooks/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-hooks/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-hooks",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "AI-powered, security-first assistance for creating Uniswap v4 hooks, including aggregator hooks, custom fee hooks, and more",
   "author": {
     "name": "Uniswap Labs",


### PR DESCRIPTION
## Summary

- Adds gas budget table with target and hard ceiling values per callback type
- Documents common gas pitfalls: unbounded loops, SSTORE costs, external calls, string ops, redundant reads
- Includes Foundry gas profiling commands (`forge test --gas-report`, `forge snapshot`)

## Context

Addresses feedback **P3-22** from the external review: the v4-security-foundations skill lacked gas budget guidance for hook callbacks.

## Test plan

- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/uniswap-hooks`
- [ ] Markdown linting passes

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Adds gas budget guidance for hook callbacks to the v4-security-foundations skill, addressing feedback **P3-22** from the external review.
## Changes
| File | Description |
|------|-------------|
| `packages/plugins/uniswap-hooks/skills/v4-security-foundations/SKILL.md` | Add Gas Budget Guidelines section (~35 lines) |
| `packages/plugins/uniswap-hooks/.claude-plugin/plugin.json` | Bump version 1.4.3 → 1.4.4 |
### New Content
| Section | Description |
|---------|-------------|
| Gas Budgets Table | Target and hard ceiling values per callback type (`beforeSwap`, `afterSwap`, liquidity callbacks, external call scenarios) |
| Common Gas Pitfalls | Documents unbounded loops, SSTORE costs, external calls, string operations, and redundant reads |
| Measuring Gas | Foundry commands for profiling (`forge test --gas-report`, `forge snapshot`) |
### Gas Budget Summary
| Callback | Target | Ceiling |
|----------|--------|---------|
| `beforeSwap` | < 50k | 150k |
| `afterSwap` | < 30k | 100k |
| Liquidity callbacks | < 50k | 200k |
| With external calls | < 100k | 300k |
## Notes
- Hook callbacks execute inside the PoolManager's transaction context — excessive gas makes swaps revert or become economically unviable
- The guidance emphasizes transient storage (`tstore`/`tload`) for data that doesn't persist beyond the transaction
- Foundry profiling commands help developers measure actual gas consumption before deployment
## Test Plan
- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/uniswap-hooks`
- [ ] Markdown linting passes
<!-- claude-pr-description-end -->