### PR TITLE
fix(uniswap-viem): add RPC rate limit guidance and mitigation strategies

### DIFF
--- a/packages/plugins/uniswap-viem/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-viem/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-viem",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "EVM blockchain integration using viem and wagmi - client setup, reading/writing data, accounts, contract interactions, and React hooks",
   "author": {
     "name": "Uniswap Labs",


### PR DESCRIPTION
## Summary

- Adds rate limit table for common providers (public RPCs, Alchemy, Infura, QuickNode)
- Documents mitigation strategies: multicall batching, fallback transport, retry config, caching
- Includes a production-ready client code example combining all strategies
- Bumps `uniswap-viem` plugin version to 1.1.2

## Context

Addresses feedback **P3-24** from the external review: the viem-integration skill mentioned public RPCs are rate-limited but provided no concrete guidance on limits or mitigation.

## Test plan

- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/uniswap-viem`
- [ ] Markdown linting passes

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Addresses feedback **P3-24** from the external review: the viem-integration skill mentioned public RPCs are rate-limited but provided no concrete guidance on limits or mitigation.
## Changes
| File | Description |
|------|-------------|
| `packages/plugins/uniswap-viem/skills/viem-integration/references/clients-and-transports.md` | Add rate limits section with provider table and mitigation strategies |
| `packages/plugins/uniswap-viem/.claude-plugin/plugin.json` | Bump version 1.1.1 → 1.1.2 |
### New Documentation
- **Rate limit table**: Free tier limits for Public RPCs (~5-10 req/s), Alchemy (330 CU/s), Infura (10 req/s), QuickNode (25 req/s)
- **Mitigation strategies**:
  1. `batch.multicall` — Batches multiple `eth_call` reads into single Multicall3 call
  2. `fallback` transport — Auto-retries on backup RPC when primary is rate-limited
  3. `retryCount`/`retryDelay` — Handles transient 429s gracefully
  4. `cacheTime` — Avoids redundant calls for unchanged data
- **Production example**: Complete client setup combining fallback transport, retry config, multicall batching, and caching
## Notes
- This is a documentation-only change with no code modifications
- The example uses Alchemy as primary, Infura as secondary, and public RPC as last resort
- Rate limits vary by provider plan; values shown are for free tiers
## Test Plan
- [ ] Plugin validates: `node scripts/validate-plugin.cjs packages/plugins/uniswap-viem`
- [ ] Markdown linting passes: `npm exec markdownlint-cli2 -- "packages/plugins/uniswap-viem/**/*.md"`
<!-- claude-pr-description-end -->