### PR TITLE
fix(ci): disable zizmor SARIF upload, use annotations instead

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -118,7 +118,7 @@ Static security analysis for GitHub Actions workflows using [zizmor](https://git
 
 - Runs on push to main and all PRs
 - Scans workflows for template injection, credential leakage, permission scope issues
-- Uploads results as SARIF to GitHub Security tab
+- Reports findings as GitHub annotations on PRs
 
 ## Required Secrets
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -13,7 +13,6 @@ jobs:
     name: Run zizmor
     runs-on: ubuntu-latest
     permissions:
-      security-events: write
       contents: read
       actions: read
     steps:
@@ -26,3 +25,6 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@0dce2577a4760a2749d8cfb7a84b7d5585ebcb7d # v0.5.0
+        with:
+          advanced-security: false
+          annotations: true


### PR DESCRIPTION
## Summary

- Disable `advanced-security` (SARIF upload) in zizmor workflow since Code Security is not enabled on this repository
- Enable `annotations` for inline PR feedback as a replacement
- Remove `security-events: write` permission that was only needed for SARIF upload

## Context

The zizmor workflow has been failing on every PR and on `main` with:
> Code Security must be enabled for this repository to use code scanning.

This switches from SARIF-based code scanning to GitHub annotations, which work without Code Security enabled while still providing inline feedback on PRs.

## Test plan

- [ ] Verify the `Run zizmor` check passes on this PR
- [ ] Verify zizmor findings appear as GitHub annotations (if any exist)

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Disable SARIF-based code scanning in the zizmor workflow and switch to GitHub annotations for inline PR feedback. The zizmor workflow was failing on every PR because Code Security is not enabled on this repository.
## Changes
| File | Description |
|------|-------------|
| `.github/workflows/zizmor.yml` | Disable `advanced-security` (SARIF upload), enable `annotations` for inline feedback, remove `security-events: write` permission |
| `.github/workflows/CLAUDE.md` | Update documentation to reflect annotations instead of SARIF upload |
### Configuration Changes
- **SARIF Upload**: Disabled via `advanced-security: false` (requires Code Security to be enabled)
- **Annotations**: Enabled via `annotations: true` (provides inline PR feedback without Code Security)
- **Permissions**: Removed `security-events: write` (only needed for SARIF upload)
## Notes
- The zizmor workflow was failing with: `Code Security must be enabled for this repository to use code scanning.`
- GitHub annotations work without Code Security enabled and still provide inline feedback on PRs where security issues are detected
- No functional change to what zizmor scans, only how results are reported
## Test Plan
- [ ] Verify the `Run zizmor` check passes on this PR
- [ ] Verify zizmor findings appear as GitHub annotations (if any exist)
<!-- claude-pr-description-end -->