### PR TITLE
fix(uniswap-trading): add browser integration guidance for swap-integration skill

### DIFF
--- a/packages/plugins/uniswap-trading/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-trading/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-trading",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "Integrate Uniswap swaps via Trading API, Universal Router SDK, or direct smart contract calls",
   "author": {
     "name": "Uniswap Labs",


### PR DESCRIPTION
## Summary

Fixes #63 — addresses 6 browser integration pitfalls discovered during real-world frontend swap app development (CornSwap).

- **CORS proxy configuration**: Documents that the Trading API doesn't support browser CORS preflight, with proxy examples for Vite, Vercel, Cloudflare Pages, and Next.js
- **Required `x-universal-router-version: 2.0` header**: Added to the Required Headers block and all 5 fetch() examples (frontend hook + backend script)
- **String chainIds in quote requests**: Fixed `tokenInChainId`/`tokenOutChainId` from numbers to strings in examples, with a callout note
- **`gasFeeUSD` response field**: Documented `gasFeeUSD` and `gasUseEstimate` in quote response with a display tip to avoid manual conversion
- **wagmi v2 integration pitfalls**: New section documenting `useWalletClient()` async resolution issue, recommending `getWalletClient`/`switchChain` from `@wagmi/core`
- **Browser troubleshooting entries**: Added 4 new rows covering CORS errors, undefined walletClient, missing chain argument, and chain mismatch

Also bumps plugin version `1.2.2` → `1.3.0` and skill version `1.1.1` → `1.2.0`.

## Test plan

- [ ] Verify all 6 issues from #63 have corresponding documentation
- [ ] Confirm all fetch() examples include all 3 required headers
- [ ] Check troubleshooting table renders correctly in markdown
- [ ] Validate cross-reference anchors resolve (CORS Proxy Configuration, wagmi v2 Integration Pitfalls)
- [ ] Run `node scripts/validate-plugin.cjs packages/plugins/uniswap-trading` — passes
- [ ] Run `npm exec markdownlint-cli2 -- --fix "packages/plugins/uniswap-trading/**/*.md"` — 0 errors

<!-- claude-pr-description-start -->
---
## :sparkles: Claude-Generated Content

## Summary
Addresses 6 browser integration pitfalls discovered during real-world frontend swap app development (CornSwap). Fixes #63.
## Changes
| Area | Description |
|------|-------------|
| **CORS proxy configuration** | Documents that the Trading API doesn't support browser CORS preflight (`OPTIONS` returns `415`); adds proxy examples for Vite, Vercel, Cloudflare Pages, and Next.js |
| **Required headers** | Adds `x-universal-router-version: 2.0` to the Required Headers block and all 5 `fetch()` examples |
| **String chainIds** | Fixes `tokenInChainId`/`tokenOutChainId` from numbers to strings in examples; adds callout note |
| **Gas fee response fields** | Documents `gasFeeUSD` and `gasUseEstimate` in quote response with display tip to avoid manual conversion |
| **wagmi v2 pitfalls** | New section documenting `useWalletClient()` async resolution issue; recommends `getWalletClient`/`switchChain` from `@wagmi/core` |
| **Troubleshooting table** | Adds 4 new rows: CORS errors, undefined walletClient, missing chain argument, chain mismatch |
### Version Bumps
- Plugin: `1.2.2` → `1.3.0`
- Skill: `1.1.1` → `1.2.0`
## Notes
- All 5 `fetch()` examples (frontend hook + backend script) now include all 3 required headers
- The wagmi v2 section provides a complete `executeSwapTransaction()` pattern using `@wagmi/core` action functions
- Cross-reference anchors added for CORS Proxy Configuration and wagmi v2 Integration Pitfalls sections
## Test Plan
- [ ] Verify all 6 issues from #63 have corresponding documentation
- [ ] Confirm all `fetch()` examples include all 3 required headers
- [ ] Check troubleshooting table renders correctly in markdown
- [ ] Validate cross-reference anchors resolve
- [ ] Run `node scripts/validate-plugin.cjs packages/plugins/uniswap-trading` — passes
- [ ] Run `npm exec markdownlint-cli2 -- "packages/plugins/uniswap-trading/**/*.md"` — 0 errors
<!-- claude-pr-description-end -->