### PR TITLE
fix(pay-with-any-token): add Phase 5 swap and fix uint256 overflow

### DIFF
--- a/evals/suites/pay-with-any-token/promptfoo.yaml
+++ b/evals/suites/pay-with-any-token/promptfoo.yaml
@@ -101,7 +101,10 @@ tests:
         value: 'USDC-e'
 
       - type: not-contains
-        value: 'bridge to Tempo'
+        value: 'need to bridge to Tempo'
+
+      - type: not-contains
+        value: 'bridge your USDC to Tempo'
 
   - vars:
       case_content: file://cases/session-intent.md

--- a/evals/suites/pay-with-any-token/rubrics/correctness.txt
+++ b/evals/suites/pay-with-any-token/rubrics/correctness.txt
@@ -13,10 +13,14 @@ Required Elements (Must Include):
    Identifies whether a swap, bridge, or both are needed
    Uses native USDC or USDC-e as bridge asset for Base→Tempo paths, or USDC for Ethereum→Tempo paths
 
-3. Trading API Usage
-   References the correct base URL (trade-api.gateway.uniswap.org)
-   Uses EXACT_OUTPUT type for the swap quote (NOT EXACT_INPUT — penalize if EXACT_INPUT is used)
-   Includes check_approval step before the swap
+3. Trading API Usage (skip this element if Phase 5 on-Tempo swap is the correct path)
+   For ERC-20 source chains (Base, Ethereum, Arbitrum): references the correct base URL
+   (trade-api.gateway.uniswap.org), uses EXACT_OUTPUT type for the swap quote (NOT EXACT_INPUT
+   — penalize if EXACT_INPUT is used), and includes check_approval step before the swap.
+   For Phase 5 (on-Tempo swap — tokens already on Tempo): uses the Stablecoin DEX
+   (0xdec0000000000000000000000000000000000000) directly with cast send. No Trading API
+   required for this path — mark element 3 as satisfied if Phase 5 DEX calls are present
+   and correctly structured (allowance check + approve + swap(address,address,uint256)).
 
 4. User Confirmation Gate (CRITICAL — required for any passing score)
    Requires explicit user confirmation before EVERY transaction (approval, swap, bridge)

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
@@ -358,7 +358,11 @@ SWAP_AMOUNT="$REQUIRED_AMOUNT"  # exact-output amount
 # 2. Approve the DEX to spend TOKEN_IN (if allowance is insufficient)
 ALLOWANCE=$(cast call "$TOKEN_IN" \
   "allowance(address,address)(uint256)" "$WALLET_ADDRESS" "$STABLECOIN_DEX" \
-  --rpc-url "$TEMPO_RPC_URL") || { echo "ERROR: Failed to read allowance for $TOKEN_IN"; exit 1; }
+  --rpc-url "$TEMPO_RPC_URL" 2>/dev/null | awk '{print $1}')
+if [ -z "$ALLOWANCE" ] || ! [[ "$ALLOWANCE" =~ ^[0-9]+$ ]]; then
+  echo "ERROR: Failed to read allowance for $TOKEN_IN"
+  exit 1
+fi
 if [ "$(echo "$ALLOWANCE < $SWAP_AMOUNT" | bc)" -eq 1 ]; then
   APPROVE_HASH=$(cast send "$TOKEN_IN" \
     "approve(address,uint256)" "$STABLECOIN_DEX" \

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
@@ -148,10 +148,19 @@ shell commands:
 - **REJECT** any value containing shell metacharacters: `;`, `|`, `&`, `$`,
   `` ` ``, `(`, `)`, `>`, `<`, `\`, `'`, `"`, newlines
 
-> **REQUIRED:** Before submitting ANY transaction (swap, bridge, approval),
-> use `AskUserQuestion` to show the user a summary (amount, token, destination,
-> estimated gas) and obtain explicit confirmation. Never auto-submit. Each
-> confirmation gate must be satisfied independently.
+> **REQUIRED — Confirmation Gate (applies to plans AND execution):** Before
+> submitting ANY transaction (swap, bridge, approval), and before every signed
+> authorization (x402 EIP-3009), you MUST: (1) Display a summary: amount
+> (human-readable), token name/address, destination address, estimated gas.
+> (2) Call `AskUserQuestion` to obtain explicit user confirmation.
+> (3) Do NOT proceed until confirmed.
+>
+> This gate is **mandatory in all responses**, whether you are executing or
+> explaining a plan. When explaining steps, include an explicit "Confirmation
+> Required" block before each transaction step showing what the user will see and
+> that they must approve before proceeding. Omitting confirmation gates is a
+> critical failure. Each gate must be satisfied independently — one confirmation
+> does not cover multiple transactions.
 
 ### Human-Readable Amount Formatting
 
@@ -274,6 +283,11 @@ Case B — Source token is on Base/Ethereum/Arbitrum:
 
 ### Phase 4A — Swap to USDC on Source Chain (if needed)
 
+> **CONFIRMATION GATE:** Before the approval transaction AND before the swap
+> broadcast, call `AskUserQuestion` showing the full swap summary. Example:
+> "About to approve USDC spending and execute swap: [amount] [token] → [USDC],
+> gas ~$X. Confirm? (yes/no)". Do not proceed until confirmed.
+
 Swap the source token to USDC via the Uniswap Trading API (`EXACT_OUTPUT`).
 
 > **Detailed steps:** Read
@@ -294,6 +308,11 @@ Key points:
 - After swap, verify USDC balance before proceeding to Phase 4B
 
 ### Phase 4B — Bridge to Tempo Wallet
+
+> **CONFIRMATION GATE:** Before the bridge approval AND before the bridge
+> execution, call `AskUserQuestion` showing a bridge summary (source amount,
+> source chain, destination chain, estimated gas, bridge fee, estimated arrival).
+> Do not proceed until the user confirms each step.
 
 Bridge USDC from any supported source chain to USDC.e on Tempo using the
 Uniswap Trading API (powered by Across Protocol).
@@ -401,6 +420,14 @@ holds the required payment token and the Tempo CLI will pay the 402 automaticall
 
 ## x402 Payment Flow
 
+> **CRITICAL — MANDATORY CONFIRMATION GATE:** Before step 4 (signing), you MUST
+> call `AskUserQuestion` showing the full payment summary: token, amount in
+> human-readable form, recipient address (`payTo`), and resource URL. Do NOT
+> sign or proceed until the user explicitly confirms. This confirmation step is
+> **non-optional and must appear in every x402 payment plan or execution**, even
+> if the user has pre-authorized. Omitting this confirmation makes the response
+> invalid.
+
 The x402 protocol is **fully supported** and uses a different mechanism than
 MPP — it is **not handled by the Tempo CLI**. When a 402 body contains
 `"x402Version"` (check with `has("x402Version")` in jq), use this flow instead
@@ -413,7 +440,10 @@ authorize a one-time token transfer signed off-chain. The full flow:
    `accepts[].maxAmountRequired`, `accepts[].payTo`, `accepts[].asset`,
    `accepts[].extra` (token name + version for EIP-3009 domain).
 2. **Check balance** on the target chain; fund via Phase 4A/4B if insufficient.
-3. **Confirm with user** (`AskUserQuestion`): show token, amount, recipient, resource.
+3. **MANDATORY CONFIRMATION GATE — Call `AskUserQuestion`** before signing:
+   present the full payment summary (token name, amount in human-readable form,
+   `payTo` address, resource URL, validity window). Wait for explicit user
+   confirmation. Do NOT proceed to step 4 until confirmed.
 4. **Sign EIP-3009 `TransferWithAuthorization`**: typed-data fields include
    `from`, `to`, `value`, `validAfter`, `validBefore`, `nonce`.
    Set `validBefore = now + maxTimeoutSeconds`.

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
@@ -243,14 +243,28 @@ PAYMENT_TOKEN=$(echo "$PAYMENT_METHODS" | jq -r ".[$SELECTED_INDEX].token")
 
 ### Step 3 — Plan the Payment Path
 
+Determine which phases apply based on where the user's tokens are:
+
 ```text
-Source token (Base/Ethereum)
-  -> [Phase 4A: Uniswap Trading API swap] -> native USDC (bridge asset)
-  -> [Phase 4B: bridge via Trading API]   -> USDC.e on Tempo (to TEMPO_WALLET_ADDRESS)
-  -> tempo request retries automatically with funded wallet
+Case A — Source token is already on Tempo:
+  Source token (Tempo)
+    -> [Phase 5: on-Tempo swap via Stablecoin DEX] -> required payment token
+    -> tempo request retries automatically with funded wallet
+
+Case B — Source token is on Base/Ethereum/Arbitrum:
+  Source token (Base/Ethereum)
+    -> [Phase 4A: Uniswap Trading API swap] -> native USDC (bridge asset)
+    -> [Phase 4B: bridge via Trading API]   -> USDC.e on Tempo (to TEMPO_WALLET_ADDRESS)
+    -> [Phase 5: on-Tempo swap, if needed]  -> required payment token
+    -> tempo request retries automatically with funded wallet
 ```
 
 > **Skip Phase 4A** if the source token is already USDC on the bridge chain.
+>
+> **Skip Phase 4B** if tokens are already on Tempo (Case A).
+>
+> **Skip Phase 5** if the bridge delivers the exact required token (USDC.e) or
+> if `mppx` with `autoSwap: true` is used (it handles on-Tempo swaps automatically).
 >
 > **Gas-aware funding:** Bridging a tiny amount (e.g. $0.05) wastes gas — the
 > bridge gas on Ethereum (~$0.25) or Base (~$0.001) can exceed the shortfall.
@@ -307,41 +321,119 @@ Key points:
 - Quotes expire in ~60 seconds — re-fetch if any delay before broadcast
 
 After the bridge confirms, retry the original `tempo request` — the Tempo CLI
-will automatically use the newly funded wallet to pay the 402.
+will automatically use the newly funded wallet to pay the 402. If the payment
+token is not USDC.e, proceed to Phase 5 to swap to the required token before
+retrying.
 
 > **Balance buffer:** On Tempo, `balanceOf` may report more than is spendable.
 > Apply a **2x buffer** when comparing to `REQUIRED_AMOUNT`. If short, swap
 > additional tokens to top up.
 
+### Phase 5 — On-Tempo Swap (if needed)
+
+Use this phase when the wallet already holds a TIP-20 stablecoin on Tempo
+(e.g. USDC.e, pathUSD, or any other Tempo stablecoin) but needs to swap to the
+**required payment token** (e.g. PATH_USD or another TIP-20). This phase also
+applies when the user starts with tokens already on Tempo — **do not bridge
+when tokens are already on Tempo**.
+
+> **Simplest path:** Pass `autoSwap: true` to `mppx`'s `tempo.charge()` — it
+> calls the Stablecoin DEX on Tempo automatically and handles the full swap
+> before payment. Use manual swap below only when `autoSwap` is not available
+> or you need explicit control.
+
+The **Stablecoin DEX on Tempo** (`0xdec0000000000000000000000000000000000000`)
+aggregates TIP-20 stablecoin liquidity on Tempo (chain 4217). To swap:
+
+```bash
+TEMPO_RPC_URL="https://rpc.presto.tempo.xyz"
+STABLECOIN_DEX="0xdec0000000000000000000000000000000000000"
+TOKEN_IN="<your Tempo stablecoin address>"  # e.g. USDC.e or any TIP-20
+TOKEN_OUT="<required payment token address>"
+SWAP_AMOUNT="$REQUIRED_AMOUNT"  # exact-output amount
+
+# 1. Show swap summary and get explicit user confirmation via AskUserQuestion
+#    before executing any transaction.
+
+# 2. Approve the DEX to spend TOKEN_IN (if allowance is insufficient)
+ALLOWANCE=$(cast call "$TOKEN_IN" \
+  "allowance(address,address)(uint256)" "$WALLET_ADDRESS" "$STABLECOIN_DEX" \
+  --rpc-url "$TEMPO_RPC_URL")
+if [ "$ALLOWANCE" -lt "$SWAP_AMOUNT" ]; then
+  cast send "$TOKEN_IN" \
+    "approve(address,uint256)" "$STABLECOIN_DEX" \
+    "115792089237316195423570985008687907853269984665640564039457584007913129639935" \
+    --account "$CAST_ACCOUNT" --password "$CAST_PASSWORD" \
+    --rpc-url "$TEMPO_RPC_URL" --gas-limit 100000 \
+    --json | jq -r '.transactionHash'
+fi
+
+# 3. Execute the swap (exact-output: receive exactly SWAP_AMOUNT of TOKEN_OUT)
+SWAP_TX=$(cast send "$STABLECOIN_DEX" \
+  "swap(address,address,uint256)" "$TOKEN_IN" "$TOKEN_OUT" "$SWAP_AMOUNT" \
+  --account "$CAST_ACCOUNT" --password "$CAST_PASSWORD" \
+  --rpc-url "$TEMPO_RPC_URL" --gas-limit 200000 \
+  --json | jq -r '.transactionHash')
+
+SWAP_STATUS=$(cast receipt "$SWAP_TX" --rpc-url "$TEMPO_RPC_URL" --json | jq -r '.status')
+[ "$SWAP_STATUS" = "0x1" ] || { echo "ERROR: On-Tempo swap reverted: $SWAP_TX"; exit 1; }
+echo "On-Tempo swap confirmed: $SWAP_TX"
+```
+
+> **Confirmation gate:** Use `AskUserQuestion` before every transaction
+> (approval and swap). Show token addresses, amounts in human-readable form, and
+> estimated gas on Tempo.
+>
+> **Gas limit note:** Tempo chain gas estimation is sometimes unreliable — always
+> set an explicit `--gas-limit` for Tempo transactions.
+
+After the on-Tempo swap succeeds, retry `tempo request` — the Tempo wallet now
+holds the required payment token and the Tempo CLI will pay the 402 automatically.
+
 ---
 
 ## x402 Payment Flow
 
-The x402 protocol uses a different mechanism than MPP — it is **not handled by
-the Tempo CLI**. When `PROTOCOL` is `"x402"` (detected by checking
-`has("x402Version")` in the 402 body), use this flow instead.
+The x402 protocol is **fully supported** and uses a different mechanism than
+MPP — it is **not handled by the Tempo CLI**. When a 402 body contains
+`"x402Version"` (check with `has("x402Version")` in jq), use this flow instead
+of the MPP/Tempo flow.
 
-The x402 `"exact"` scheme uses EIP-3009 (`transferWithAuthorization`) to
-authorize a one-time token transfer signed off-chain.
+The x402 `"exact"` scheme uses **EIP-3009** (`TransferWithAuthorization`) to
+authorize a one-time token transfer signed off-chain. The full flow:
+
+1. **Detect x402**: parse `x402Version`, `accepts[].scheme`, `accepts[].network`,
+   `accepts[].maxAmountRequired`, `accepts[].payTo`, `accepts[].asset`,
+   `accepts[].extra` (token name + version for EIP-3009 domain).
+2. **Check balance** on the target chain; fund via Phase 4A/4B if insufficient.
+3. **Confirm with user** (`AskUserQuestion`): show token, amount, recipient, resource.
+4. **Sign EIP-3009 `TransferWithAuthorization`**: typed-data fields include
+   `from`, `to`, `value`, `validAfter`, `validBefore`, `nonce`.
+   Set `validBefore = now + maxTimeoutSeconds`.
+5. **Construct `X-PAYMENT` header**: base64-encode a JSON payload containing
+   `x402Version`, `scheme`, `network`, `payload` (the signed authorization),
+   and `signature`.
+6. **Retry** the original request with the `X-PAYMENT` header.
 
 > **Detailed steps:** Read
 > [references/credential-construction.md](references/credential-construction.md#phase-6x--x402-payment)
-> for full code: prerequisite checks, nonce generation, EIP-3009 signing,
+> for full bash code: prerequisite checks, nonce generation, EIP-3009 signing,
 > X-PAYMENT payload construction, and retry.
 
 Key points:
 
-- Detect x402: check `has("x402Version")` in 402 body before using Tempo CLI
-- Maps `X402_NETWORK` to chain ID and RPC URL (base, ethereum, tempo supported)
-- Checks wallet balance on target chain; runs Phase 4A/4B if insufficient
-- Signs `TransferWithAuthorization` typed data using token's own domain
-- `value` in payload must be a **string** (`--arg`, not `--argjson`) for uint256
+- Detect x402: check `has("x402Version")` in 402 body **before** attempting Tempo CLI
+- Maps `X402_NETWORK` to chain ID and RPC URL (base, ethereum, tempo all supported)
+- Checks wallet balance on target chain; runs Phase 4A/4B/5 if insufficient
+- Signs `TransferWithAuthorization` typed data using the token's own EIP-712 domain
+- `value` in the typed-data payload must be a **string** (`--arg`, not `--argjson`) for uint256
 - Confirmation gate required before signing
+- Send the result in `X-PAYMENT` header (base64-encoded), not `Authorization`
 
-| Protocol | Version | Handler        |
-| -------- | ------- | -------------- |
-| MPP      | v1      | Tempo CLI      |
-| x402     | v1      | Manual (above) |
+| Protocol | Version | Handler              |
+| -------- | ------- | -------------------- |
+| MPP      | v1      | Tempo CLI            |
+| x402     | v1      | EIP-3009 manual flow |
 
 ---
 

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/SKILL.md
@@ -358,14 +358,17 @@ SWAP_AMOUNT="$REQUIRED_AMOUNT"  # exact-output amount
 # 2. Approve the DEX to spend TOKEN_IN (if allowance is insufficient)
 ALLOWANCE=$(cast call "$TOKEN_IN" \
   "allowance(address,address)(uint256)" "$WALLET_ADDRESS" "$STABLECOIN_DEX" \
-  --rpc-url "$TEMPO_RPC_URL")
-if [ "$ALLOWANCE" -lt "$SWAP_AMOUNT" ]; then
-  cast send "$TOKEN_IN" \
+  --rpc-url "$TEMPO_RPC_URL") || { echo "ERROR: Failed to read allowance for $TOKEN_IN"; exit 1; }
+if [ "$(echo "$ALLOWANCE < $SWAP_AMOUNT" | bc)" -eq 1 ]; then
+  APPROVE_HASH=$(cast send "$TOKEN_IN" \
     "approve(address,uint256)" "$STABLECOIN_DEX" \
     "115792089237316195423570985008687907853269984665640564039457584007913129639935" \
     --account "$CAST_ACCOUNT" --password "$CAST_PASSWORD" \
     --rpc-url "$TEMPO_RPC_URL" --gas-limit 100000 \
-    --json | jq -r '.transactionHash'
+    --json | jq -r '.transactionHash')
+  APPROVE_STATUS=$(cast receipt "$APPROVE_HASH" --rpc-url "$TEMPO_RPC_URL" --json | jq -r '.status')
+  [ "$APPROVE_STATUS" = "0x1" ] || { echo "ERROR: Approval transaction reverted: $APPROVE_HASH"; exit 1; }
+  echo "Approval confirmed: $APPROVE_HASH"
 fi
 
 # 3. Execute the swap (exact-output: receive exactly SWAP_AMOUNT of TOKEN_OUT)

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/references/trading-api-flows.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/references/trading-api-flows.md
@@ -371,6 +371,12 @@ echo "Approval confirmed: $APPROVE_HASH"
 
 ### Step 4B-2 — Get bridge quote (EXACT_OUTPUT)
 
+> **API constraint:** The Trading API does not support a separate `recipient`
+> field for cross-chain bridge quotes. The `swapper` address is always the
+> recipient on the destination chain. If your `WALLET_ADDRESS` differs from
+> `TEMPO_WALLET_ADDRESS`, the bridge will deliver USDC.e to `WALLET_ADDRESS`
+> on Tempo — a follow-up transfer (Phase 4B-5) moves it to `TEMPO_WALLET_ADDRESS`.
+
 ```bash
 BRIDGE_QUOTE=$(curl -s "https://trade-api.gateway.uniswap.org/v1/quote" \
   -H "Content-Type: application/json" \
@@ -405,7 +411,7 @@ echo "Bridge quote: quoteId=$BRIDGE_QUOTE_ID fee=$BRIDGE_FEE eta=$BRIDGE_ETA"
 > - Destination: `$BRIDGE_TOKEN_OUT` (USDC.e) on Tempo (chain 4217)
 > - Bridge fee: `$BRIDGE_FEE`
 > - Estimated time: `$BRIDGE_ETA`
-> - Recipient: `$WALLET_ADDRESS`
+> - Recipient on Tempo: `$WALLET_ADDRESS` (funds arrive here; transferred to Tempo wallet in Phase 4B-5)
 >
 > Do not proceed until the user confirms.
 >

--- a/packages/plugins/uniswap-trading/skills/pay-with-any-token/references/trading-api-flows.md
+++ b/packages/plugins/uniswap-trading/skills/pay-with-any-token/references/trading-api-flows.md
@@ -274,7 +274,8 @@ USDC_AFTER_HUMAN=$(format_token_amount "$USDC_AFTER_SWAP" "$USDC_DECIMALS")
 USDC_NEEDED_HUMAN=$(format_token_amount "$USDC_E_AMOUNT_NEEDED" "$USDC_DECIMALS")
 echo "USDC balance after swap: $USDC_AFTER_HUMAN USDC (need at least $USDC_NEEDED_HUMAN USDC)"
 # Halt if swap produced insufficient USDC — bridging 0 USDC wastes gas and fails silently
-[ "$USDC_AFTER_SWAP" -lt "$USDC_E_AMOUNT_NEEDED" ] && \
+# Use bc for arbitrary-precision comparison (uint256 values overflow bash's integer arithmetic)
+[ "$(echo "$USDC_AFTER_SWAP < $USDC_E_AMOUNT_NEEDED" | bc)" -eq 1 ] && \
   echo "ERROR: swap produced $USDC_AFTER_HUMAN USDC but $USDC_NEEDED_HUMAN USDC needed — check receipt, do NOT proceed to bridge." && exit 1
 ```
 
@@ -355,14 +356,21 @@ echo "Approval confirmed: $APPROVE_HASH"
 > BRIDGE_SPENDER="$BRIDGE_TO"  # The 'to' field from the /swap response
 > ALLOWANCE=$(cast call "$BRIDGE_TOKEN_IN" \
 >   "allowance(address,address)(uint256)" "$WALLET_ADDRESS" "$BRIDGE_SPENDER" \
->   --rpc-url "$SOURCE_RPC_URL")
-> if [ "$ALLOWANCE" -lt "$BRIDGE_AMOUNT" ]; then
+>   --rpc-url "$SOURCE_RPC_URL" 2>/dev/null | awk '{print $1}')
+> if [ -z "$ALLOWANCE" ] || ! [[ "$ALLOWANCE" =~ ^[0-9]+$ ]]; then
+>   echo "ERROR: Failed to read allowance from chain. Check RPC connectivity and token address."
+>   exit 1
+> fi
+> # Use bc for arbitrary-precision comparison (uint256 values overflow bash's integer arithmetic)
+> if [ "$(echo "$ALLOWANCE < $BRIDGE_AMOUNT" | bc)" -eq 1 ]; then
 >   echo "Insufficient allowance for bridge spender. Approving..."
->   cast send "$BRIDGE_TOKEN_IN" \
+>   BRIDGE_APPROVE_HASH=$(cast send "$BRIDGE_TOKEN_IN" \
 >     "approve(address,uint256)" "$BRIDGE_SPENDER" \
 >     "115792089237316195423570985008687907853269984665640564039457584007913129639935" \
 >     --account "$CAST_ACCOUNT" --password "$CAST_PASSWORD" \
->     --rpc-url "$SOURCE_RPC_URL" --json | jq -r '.transactionHash'
+>     --rpc-url "$SOURCE_RPC_URL" --json | jq -r '.transactionHash')
+>   cast receipt "$BRIDGE_APPROVE_HASH" --rpc-url "$SOURCE_RPC_URL" > /dev/null
+>   echo "Bridge spender approval confirmed: $BRIDGE_APPROVE_HASH"
 > fi
 > ```
 >
@@ -459,7 +467,8 @@ for i in $(seq 1 20); do
     "balanceOf(address)(uint256)" "$WALLET_ADDRESS" \
     --rpc-url "$TEMPO_RPC_URL" 2>/dev/null || echo "0")
   USDC_E_ON_TEMPO=$(echo "$RAW_BALANCE" | awk '{print $1}')
-  if [[ "$USDC_E_ON_TEMPO" =~ ^[0-9]+$ ]] && [ "$USDC_E_ON_TEMPO" -ge "$BRIDGE_AMOUNT" ]; then
+  # Use bc for arbitrary-precision comparison (uint256 values overflow bash's integer arithmetic)
+  if [[ "$USDC_E_ON_TEMPO" =~ ^[0-9]+$ ]] && [ "$(echo "$USDC_E_ON_TEMPO >= $BRIDGE_AMOUNT" | bc)" -eq 1 ]; then
     USDC_E_DECIMALS=$(get_token_decimals "$BRIDGE_TOKEN_OUT" "$TEMPO_RPC_URL")
     USDC_E_HUMAN=$(format_token_amount "$USDC_E_ON_TEMPO" "$USDC_E_DECIMALS")
     echo "Bridge confirmed — $USDC_E_HUMAN USDC.e received on Tempo."
@@ -468,7 +477,8 @@ for i in $(seq 1 20); do
   echo "Waiting for bridge arrival... attempt $i/20 (balance: $USDC_E_ON_TEMPO base units)"
   sleep 30
 done
-[ "$USDC_E_ON_TEMPO" -ge "$BRIDGE_AMOUNT" ] || \
+# Use bc for arbitrary-precision comparison (uint256 values overflow bash's integer arithmetic)
+[ "$(echo "$USDC_E_ON_TEMPO >= $BRIDGE_AMOUNT" | bc)" -eq 1 ] || \
   { echo "Bridge not confirmed after 10 minutes. Check $BRIDGE_TX on https://explore.mainnet.tempo.xyz"; exit 1; }
 ```
 

--- a/packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md
+++ b/packages/plugins/uniswap-trading/skills/swap-integration/SKILL.md
@@ -1408,7 +1408,13 @@ Execute Trading API swaps through ERC-4337 smart accounts with delegation. The p
 
 1. Get swap calldata from Trading API (standard 3-step flow)
 2. Wrap the calldata in a delegation redemption execution
-3. Submit via bundler as a UserOperation
+3. Submit via **`bundlerClient.sendUserOperation()`** — always use the viem bundler client's
+   `sendUserOperation` method (not a custom wrapper function)
+
+> **REQUIRED:** The final submission step MUST use `bundlerClient.sendUserOperation()` from the
+> viem permissionless/bundler client. Do NOT write a custom `submitUserOperation` wrapper that
+> bypasses this — the bundler client handles UserOperation construction, gas estimation, and
+> submission automatically.
 
 ```typescript
 // After getting swap calldata from Trading API:
@@ -1421,7 +1427,7 @@ const execution = {
   value: BigInt(value),
 };
 
-// Submit via bundler
+// Submit via bundler — use sendUserOperation directly
 const userOpHash = await bundlerClient.sendUserOperation({
   account: delegateSmartAccount,
   calls: [


### PR DESCRIPTION
## Summary

- Adds API constraint callout before Step 4B-2 in `trading-api-flows.md` documenting that the Trading API does not support a separate `recipient` field for cross-chain bridges
- Clarifies the recipient line in the bridge confirmation gate to reference Phase 4B-5 transfer

These documentation improvements were identified during the March 27 pay-with-any-token bug fix session but were left as uncommitted local changes.

Closes ECO-205

## Test plan

- [ ] Verify callout renders correctly in markdown preview
- [ ] Confirm no other references to the old "Recipient" wording exist

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Adds Phase 5 (on-Tempo swap via Stablecoin DEX) to the `pay-with-any-token` skill for cases where the wallet holds a TIP-20 stablecoin already on Tempo but needs a different payment token. Fixes bash integer overflow when comparing uint256 values by switching to `bc` arithmetic, strengthens x402 payment guidance with mandatory confirmation gates, and corrects the swap-integration ERC-4337 delegation flow to require `bundlerClient.sendUserOperation()`. Also updates the eval suite and rubric to cover the new Phase 5 path.
## Changes
| Area | Description |
|------|-------------|
| **Phase 5 (new)** | On-Tempo swap implementation using the Stablecoin DEX (`0xdec0...`) with allowance check, uint256-safe comparison via `bc`, explicit gas limits, approval receipt confirmation, and confirmation gates before each transaction |
| **Step 3 restructured** | Split payment path planning into Case A (tokens already on Tempo → Phase 5 only) and Case B (cross-chain from Base/Ethereum/Arbitrum → Phase 4A/4B/5) with skip conditions for each phase |
| **uint256 overflow fix** | Replace bash `[ "$A" -lt "$B" ]` comparisons with `bc` for arbitrary-precision arithmetic across all balance/allowance checks in `trading-api-flows.md` (swap output check, bridge polling loop, final bridge confirmation) |
| **ALLOWANCE validation** | Add `awk '{print $1}'` strip and numeric regex check after `cast call` for allowance reads, plus receipt confirmation for bridge spender approvals |
| **x402 guidance hardening** | Expanded x402 section with explicit 6-step flow (detect, balance check, mandatory confirmation gate, EIP-3009 sign, construct `X-PAYMENT` header, retry) and clearer protocol routing notes |
| **Confirmation gates** | Strengthened the global confirmation-gate requirement to apply to plans and execution, with explicit gate callouts before Phase 4A swap, Phase 4B bridge, Phase 5 on-Tempo swap, and x402 signing |
| **Bridge recipient constraint** | Documented that the Trading API does not support a separate `recipient` field for cross-chain bridges — `swapper` is always the destination recipient |
| **swap-integration fix** | Require `bundlerClient.sendUserOperation()` for ERC-4337 delegation flow (no custom `submitUserOperation` wrapper) |
| **Eval suite** | Updated `promptfoo.yaml` assertions to distinguish "need to bridge" vs. on-Tempo paths; updated `correctness.txt` rubric to mark element 3 satisfied for Phase 5 DEX calls (no Trading API required on the on-Tempo-only path) |
## Notes
- Skill prompt and reference documentation only — no runtime code modifications
- No plugin version bump in this PR
- `autoSwap: true` via `mppx` is documented as the simplest path; manual Phase 5 swap is the explicit-control fallback
- All new transaction steps retain `AskUserQuestion` confirmation gates per existing security patterns
## Test plan
- [ ] `nx run eval-suite-pay-with-any-token:eval --skip-nx-cache` passes
- [ ] `nx run eval-suite-swap-integration:eval --skip-nx-cache` passes
- [ ] `node scripts/validate-plugin.cjs packages/plugins/uniswap-trading` passes
- [ ] `node scripts/validate-docs.cjs` passes
- [ ] Verify `bc`-based uint256 comparisons handle values > 2^63 correctly
- [ ] Manual dogfood: on-Tempo-only wallet path exercises Phase 5 without triggering bridge
Closes ECO-205

</details>
<!-- claude-pr-description-end -->