### PR TITLE
chore(ci): bump ai-toolkit reusable workflow pin

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -207,7 +207,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -258,7 +258,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -290,7 +290,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -207,7 +207,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@4d55967a0d8d941e8c815b3d2daea3770fecbc98
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -258,7 +258,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@4d55967a0d8d941e8c815b3d2daea3770fecbc98
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -290,7 +290,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@4d55967a0d8d941e8c815b3d2daea3770fecbc98
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -207,7 +207,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -258,7 +258,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -290,7 +290,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@084ed0f93757da101364aecd5dd453cd3e888ff5 # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09 # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09 # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306 # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@4d55967a0d8d941e8c815b3d2daea3770fecbc98 # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@084ed0f93757da101364aecd5dd453cd3e888ff5 # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,7 +47,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@4d55967a0d8d941e8c815b3d2daea3770fecbc98
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,7 +47,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,7 +47,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@084ed0f93757da101364aecd5dd453cd3e888ff5
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@e22669e1063f4540caa0bc0ffe1fb7d813ed0b09
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
Bumps pins on `Uniswap/ai-toolkit` reusable workflows from `4d55967a` to `96ef665b` (current `main` HEAD) to pick up upstream changes.