### PR TITLE
fix(ci): drop removed plugin_ref input from docs-check caller

### DIFF
--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -67,7 +67,6 @@ jobs:
       fail_on_missing_docs: true
       # Use main branch of ai-toolkit for scripts
       toolkit_ref: 'main'
-      plugin_ref: 'main'
     secrets:
       # Use OAuth token (Pro/Max) instead of API key
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- The Claude Docs Check workflow has been failing with `startup_failure` (no jobs, no logs) on every PR since 2026-03-31.
- Root cause: this caller passes `plugin_ref: 'main'`, but the upstream reusable workflow `Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml` removed that input in `ai-toolkit@d487cf5` (PR Uniswap/ai-toolkit#423) when `build-plugin-config` was collapsed to a single SHA-pinned step. GitHub validates reusable-workflow inputs during workflow setup and rejects undeclared ones, which kills the run before any job is created.
- Fix: delete the orphaned `plugin_ref: 'main'` line in `.github/workflows/claude-docs-check.yml`. No other callers in this repo pass `plugin_ref`.

## What changed

- `.github/workflows/claude-docs-check.yml`: removed the `plugin_ref: 'main'` input. The currently-pinned ai-toolkit SHA `96ef665…` (and every SHA past `d487cf5`) no longer accepts it.

## Test plan

- [x] `actionlint .github/workflows/claude-docs-check.yml` — clean.
- [x] Verified the `Uniswap/ai-toolkit` reusable workflow at the pinned SHA (`96ef665ba04221de07e94fcc3ea69fe32c7cf306`) declares `workflow_call.inputs` of: `pr_number`, `base_ref`, `suggestion_mode`, `auto_commit`, `fail_on_missing_docs`, `fail_on_missing_version`, `model`, `max_turns`, `timeout_minutes`, `toolkit_ref`, `install_uniswap_plugins`, `exclude_plugins`, `auto_fix`, `auto_fix_model`. `plugin_ref` is absent.
- [x] Searched `.github/` for other `plugin_ref` references — none remain.
- [x] Confirmed sibling callers `claude-code-review.yml` and `generate-pr-title-description.yml` do not pass `plugin_ref` and have been running green.
- [ ] After merge: the Claude Docs Check run on this PR (and subsequent PRs) should produce a real job instead of `startup_failure`.

## Session context

### Investigation

Started from PR #105, where `docs-check` was visibly missing from the checks rollup. Tracing it:

1. The workflow IS triggered — `gh run list --workflow=claude-docs-check.yml` shows runs, but every one since 2026-03-31 has `conclusion=startup_failure` with no associated jobs and no fetchable logs.
2. `gh api repos/Uniswap/uniswap-ai/actions/runs/<id>` reveals `referenced_workflows[0].sha = 96ef665…`, i.e. main's pin — not whatever the PR branch was based on. For `pull_request` events GitHub uses the workflow file from the merge ref, so unless the PR touches the workflow itself, it gets main's version.
3. Cross-checking the caller's `with:` block against the `workflow_call.inputs` schema at SHA `96ef665…` showed `plugin_ref` was the lone undeclared input.
4. `git log -S "plugin_ref" -- .github/workflows/_claude-docs-check.yml` in `Uniswap/ai-toolkit` points to commit `d487cf5` (PR Uniswap/ai-toolkit#423, 2026-03-30): \"fix(ci): pin build-plugin-config to full SHAs\". That PR collapsed the two conditional `build-plugin-config@main`/`@next` steps into one pinned to a fixed SHA, which removed the need for `plugin_ref`. The cleanup updated 8 in-tree callers but didn't sweep external consumers like this repo.
5. The breakage stayed latent until uniswap-ai PR #95 (2026-04-07) bumped the reusable-workflow pin past `d487cf5`.

### Options evaluated and rejected

- **Pin the reusable workflow back to a pre-`d487cf5` SHA.** Rejected — that would lose ~6 weeks of upstream fixes (including the actionlint hardening, the auto-fix work, and the `exclude_plugins` input) and silently re-introduce the unpinned `@main` / `@next` action references that caused PR #423 in the first place.
- **Keep `plugin_ref` and ignore the failures.** Rejected — startup failures aren't a required check, but they make the docs-check feature non-functional, and noisy `startup_failure` events make it harder to spot real regressions in the rollup.

### Constraints discovered

- GitHub's reusable-workflow input validation runs at workflow *setup*, before any job is allocated. The resulting `startup_failure` has no Job to attach logs/annotations to, which is why `gh run view --log` returns `log not found` and the GitHub UI shows nothing actionable. The only diagnostic surface is the run's `referenced_workflows` field via the REST API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
The Claude Docs Check workflow has been failing with `startup_failure` on every PR since 2026-03-31. Root cause: this caller passes `plugin_ref: 'main'`, but the upstream reusable workflow (`Uniswap/ai-toolkit/_claude-docs-check.yml`) removed that input in `ai-toolkit@d487cf5` (PR Uniswap/ai-toolkit#423). GitHub rejects undeclared reusable-workflow inputs at setup time, killing the run before any job is created.
## Changes
- `.github/workflows/claude-docs-check.yml`: removed the orphaned `plugin_ref: 'main'` input line. The pinned ai-toolkit SHA (`96ef665…`) and every SHA past `d487cf5` no longer accepts this input.
## Notes
- The `startup_failure` conclusion produces no jobs and no fetchable logs — the only diagnostic is the run's `referenced_workflows` field via the REST API.
- Sibling callers (`claude-code-review.yml`, `generate-pr-title-description.yml`) do not pass `plugin_ref` and have been running green.
- Verified via `actionlint` — clean after this change.
## Test plan
- [ ] After merge: Claude Docs Check runs on subsequent PRs should produce real jobs instead of `startup_failure`

</details>
<!-- claude-pr-description-end -->