### PR TITLE
chore(ci): bump ai-toolkit pin to 83ac42b for bullfrog allowlist fix

### DIFF
--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@96ef665ba04221de07e94fcc3ea69fe32c7cf306 # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}


### PR DESCRIPTION
## Summary

- After #106 fixed the schema mismatch that was hiding behind `startup_failure`, the docs-check job started actually running — and timing out after 15 minutes.
- Root cause: at the previous pin (`96ef665`), `bullfrogsec/bullfrog` ran with `egress-policy: block` and an allowlist that did *not* include `registry.npmjs.org`. The Claude Code action's tool processes appear to hit the npm registry at runtime; every request was blocked, and the action retried until the 15-minute job timeout killed it.
- ai-toolkit#501 (now on main at `83ac42b`) adds `registry.npmjs.org`, `*.npmjs.org`, `claude.ai`, `*.claude.ai` to the bullfrog allowlist and bumps `anthropics/claude-code-action` to v1.0.119. This PR bumps the uniswap-ai pin past that fix.

## What changed

- `.github/workflows/claude-docs-check.yml`: bumped the reusable-workflow pin from `96ef665ba04221de07e94fcc3ea69fe32c7cf306` to `83ac42bf6a63fdaa2fc71c760b02ab85df21068a` (one line).

## Test plan

- [x] `actionlint .github/workflows/claude-docs-check.yml` — clean.
- [x] Verified the reusable workflow at `83ac42b` has `registry.npmjs.org` in its bullfrog allowlist and uses `claude-code-action@v1.0.119` (vs. v1.0.75 at the old pin).
- [ ] After merge: a docs-check run should complete (verdict PASS/FAIL with a real Claude analysis) instead of timing out at 15:00.

## Session context

### Investigation

Following PR #106, the docs-check job on the same branch went from `startup_failure` → `CANCELLED`. The job ran 15:17 and the \"Run Claude Docs Check\" step was killed at exactly 14:39 elapsed — the `timeout_minutes` default in the reusable workflow.

Log analysis (`gh run view ... --log`) showed the step's tail was dominated by repeated `[+058329-04-14T...] Blocked DNS request to registry.npmjs.org from unknown process` warnings — bullfrog's egress sandbox firing for the full duration. Far-future timestamps are bullfrog's internal sandbox clock, not real time.

`git log -S 'registry.npmjs' .github/workflows/_claude-docs-check.yml` in `Uniswap/ai-toolkit` pointed to `3a4dbad` (ai-toolkit#501): \"fix(workflows): bump claude-code-action and expand egress allowlists\". That diff:

```
+            claude.ai
+            *.claude.ai
             bun.sh
+            registry.npmjs.org
+            *.npmjs.org
```

…plus a bump of `anthropics/claude-code-action` from v1.0.75 → v1.0.115 (then v1.0.119 by the time of `83ac42b`). The fix landed on ai-toolkit `main` between PR #106 being authored and this PR.

### Options evaluated and rejected

- **Bump `timeout_minutes` in the caller.** Rejected — the root cause is bullfrog blocking npm DNS, not a slow run. More time just burns more Anthropic spend on the same retry loop.
- **Override the bullfrog allowlist locally in the caller.** Not possible: the reusable workflow's `bullfrogsec/bullfrog` step runs inside the reusable workflow itself; the caller doesn't have a hook to amend its `with:` block. The fix has to come from ai-toolkit.
- **Pin to an even newer SHA than `83ac42b`.** `83ac42b` is current ai-toolkit `main` HEAD as of this PR and is the first commit that contains the fix's stable form (v1.0.119 of claude-code-action). Going further chases a moving target.

### Related

- Builds on #106, which removed the `plugin_ref` input that was causing `startup_failure` upstream of this issue.
- The same out-of-date pin (`96ef665`) is also used by `claude-code-review.yml` and `generate-pr-title-description.yml`. Those workflows are currently green, so they're not strictly broken, but they will pick up the same bullfrog allowlist gap the next time a Claude tool call needs `npm`. Worth bumping in a follow-up if we see similar timeouts elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Bumps the `ai-toolkit` reusable workflow pin in `claude-docs-check.yml` from `96ef665` to `83ac42b` to pick up the bullfrog egress allowlist fix that was causing the docs-check job to time out.
## Changes
- `.github/workflows/claude-docs-check.yml`: updated reusable workflow SHA from `96ef665ba04221de07e94fcc3ea69fe32c7cf306` to `83ac42bf6a63fdaa2fc71c760b02ab85df21068a`
## Notes
- After #106 fixed the `startup_failure`, the docs-check job started actually running but timed out at 15 minutes because `bullfrogsec/bullfrog` was blocking DNS requests to `registry.npmjs.org`
- The new pin (`83ac42b`, ai-toolkit#501) adds `registry.npmjs.org`, `*.npmjs.org`, `claude.ai`, `*.claude.ai` to the bullfrog allowlist and bumps `anthropics/claude-code-action` to v1.0.119
- Sibling workflows (`claude-code-review.yml`, `generate-pr-title-description.yml`) still use the old pin (`96ef665`) — worth bumping in a follow-up if similar timeouts appear
## Test plan
- [ ] `actionlint .github/workflows/claude-docs-check.yml` — clean
- [ ] After merge: docs-check run completes with a real Claude analysis instead of timing out

</details>
<!-- claude-pr-description-end -->