### PR TITLE
fix(workflows): randomize $GITHUB_OUTPUT heredoc delimiter

### DIFF
--- a/.github/actions/validate-plugins/action.yml
+++ b/.github/actions/validate-plugins/action.yml
@@ -128,12 +128,17 @@ runs:
         echo "plugin_count=$PLUGINS_COUNT" >> $GITHUB_OUTPUT
         echo "marketplace_name=$MARKETPLACE_NAME" >> $GITHUB_OUTPUT
 
-        # Handle multiline JSON output
+        # Handle multiline JSON output with a per-call unguessable delimiter
+        # (defense in depth against $GITHUB_OUTPUT injection).
+        RESULTS_DELIM_RAND=$(openssl rand -hex 16)
+        [ -n "$RESULTS_DELIM_RAND" ] || { echo "::error::openssl rand returned empty" >&2; exit 1; }
+        [ "$(printf '%s' "$RESULTS" | wc -c)" -lt 900000 ] || { echo "::error::plugins_json exceeds 900KB" >&2; exit 1; }
+        RESULTS_DELIM="PLUGINS_JSON_DELIMITER_$(date +%s%N)_${RESULTS_DELIM_RAND}"
         {
-          echo "plugins_json<<EOF"
+          echo "plugins_json<<${RESULTS_DELIM}"
           echo "$RESULTS"
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
+          echo "${RESULTS_DELIM}"
+        } >> "$GITHUB_OUTPUT"
 
         # Create job summary
         {


### PR DESCRIPTION
## Summary

Shell-driven steps in this repo write multiline values to `$GITHUB_OUTPUT` using static heredoc delimiters (`EOF`, `CHANGELOG`, `COVERAGE`, etc.). Per the [multiline-string spec](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), the parser terminates a value the moment it reads a line equal to the active delimiter and resolves duplicate keys as last-write-wins. A static delimiter inside any caller-controlled heredoc body is a structural injection sink.

**None of the patched sites in this repo are currently exploitable** — their heredoc bodies are derived from deterministic sources (git log, git diff, forge coverage, internal Pulumi config, etc.) with no current path for attacker-controlled freeform text. Patched as defense-in-depth so a future edit that splices caller-controlled content into any of these bodies does not silently introduce the class. Mirrors the per-call random delimiter already shipped in `Uniswap/ai-toolkit/.github/scripts/build-prompt.ts:generateUniqueDelimiter` ("to prevent injection attacks", commit `7159a4f`).

## What changed

Each affected site now:
- Generates a delimiter as `<PREFIX>_DELIMITER_<date +%s%N>_<openssl rand -hex 16>` (128-bit CSPRNG + nanosecond timestamp).
- Asserts the random component is non-empty before use (bash `-e` does not abort on a failing command substitution inside a variable assignment; without this, an openssl regression would silently degrade the delimiter to a predictable prefix+timestamp).
- Refuses to write values exceeding 900KB (conservative cap below the `$GITHUB_OUTPUT` 1MB per-value limit; >1MB writes truncate mid-body and leave an unclosed heredoc that the parser misinterprets).

## Session context

Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509) — the exploitable instances of the same class.

A wider grep across all Uniswap public repos found this anti-pattern in this repo, where the heredoc body is a deterministic value with no current attacker input path. Including the fix here is hygiene + future-proofing.

## Test plan

The pattern was pressure-tested locally in the context of the exploitable repos:
- Attacker injection contained — embedded inside the legitimate body, not promoted to a duplicate key.
- Benign body round-trips correctly.
- Delimiter uniqueness across runs (128-bit CSPRNG).
- openssl-empty abort (simulated via PATH override; step exits non-zero, zero bytes written).
- Oversize abort (900001-byte body; step exits non-zero, zero bytes written).
- Just-under-cap success (899999-byte body writes successfully).

All assertions pass. YAML in this PR validates with `yaml.safe_load`.

To verify post-merge: trigger the relevant workflow run and confirm the step output is consumed correctly downstream.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Hardens the `validate-plugins` composite action against a `$GITHUB_OUTPUT` heredoc-injection class. The site writes the `plugins_json` multiline output using a static `EOF` delimiter; per the [multiline-string spec](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings), the parser terminates the value the moment it reads a line equal to the active delimiter and resolves duplicate keys as last-write-wins, making any static delimiter inside a caller-controlled heredoc body a structural injection sink.
**The patched site is not currently exploitable** — the heredoc body comes from `node scripts/validate-plugin.cjs` output, a deterministic source with no current path for attacker-controlled freeform text. Patched as defense-in-depth so a future edit that splices caller-controlled content into this body does not silently introduce the class. Mirrors the per-call random delimiter already shipped in `Uniswap/ai-toolkit/.github/scripts/build-prompt.ts:generateUniqueDelimiter` ("to prevent injection attacks", commit `7159a4f`).
## What changed
`.github/actions/validate-plugins/action.yml` — the `plugins_json` output write now:
- Generates a delimiter as `PLUGINS_JSON_DELIMITER_<date +%s%N>_<openssl rand -hex 16>` (128-bit CSPRNG + nanosecond timestamp).
- Asserts the random component is non-empty before use — bash `-e` does not abort on a failing command substitution inside a variable assignment, so without this, an openssl regression would silently degrade the delimiter to a predictable prefix+timestamp.
- Refuses to write values exceeding 900KB (conservative cap below the `$GITHUB_OUTPUT` 1MB per-value limit; >1MB writes truncate mid-body and leave an unclosed heredoc that the parser misinterprets).
- Quotes `"$GITHUB_OUTPUT"` for consistency with the rest of the file.
## Session context
Discovered during the bug bounty review that produced [Uniswap/default-token-list#2484](https://github.com/Uniswap/default-token-list/pull/2484) and [Uniswap/ai-toolkit#509](https://github.com/Uniswap/ai-toolkit/pull/509) — the exploitable instances of the same class. A wider grep across Uniswap public repos surfaced this site, where the heredoc body is deterministic with no current attacker input path. Including the fix here is hygiene + future-proofing.
## Test plan
The pattern was pressure-tested locally in the context of the exploitable repos:
- [x] Attacker injection contained — embedded inside the legitimate body, not promoted to a duplicate key.
- [x] Benign body round-trips correctly.
- [x] Delimiter uniqueness across runs (128-bit CSPRNG).
- [x] openssl-empty abort (simulated via PATH override; step exits non-zero, zero bytes written).
- [x] Oversize abort (900001-byte body; step exits non-zero, zero bytes written).
- [x] Just-under-cap success (899999-byte body writes successfully).
- [x] YAML in this PR validates with `yaml.safe_load`.
- [ ] Post-merge: trigger a workflow run that consumes `plugins_json` and confirm downstream steps parse it correctly.

</details>
<!-- claude-pr-description-end -->