### PR TITLE
chore(deps): maintain Claude Code Action workflows (cca=v1.0.133, ait=824dfc1)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -219,7 +219,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -227,7 +227,7 @@ jobs:
       max_diff_lines: 5000
 
       # Use Sonnet for fast, cost-effective reviews
-      model: 'claude-sonnet-4-5-20250929'
+      model: 'claude-sonnet-4-6'
 
       # Standard timeout for most PRs
       timeout_minutes: 20
@@ -270,7 +270,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -278,7 +278,7 @@ jobs:
       max_diff_lines: 5000
 
       # Use Sonnet for fast, cost-effective reviews
-      model: 'claude-sonnet-4-5-20250929'
+      model: 'claude-sonnet-4-6'
 
       # Standard timeout for most PRs
       timeout_minutes: 20
@@ -302,7 +302,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -310,7 +310,7 @@ jobs:
       max_diff_lines: 5000
 
       # Use Sonnet for fast, cost-effective reviews
-      model: 'claude-sonnet-4-5-20250929'
+      model: 'claude-sonnet-4-6'
 
       # Standard timeout for most PRs
       timeout_minutes: 20

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,13 +54,13 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4 # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}
       auto_commit: ${{ github.event.inputs.auto_commit == 'true' }}
       # Use sonnet for faster, cheaper checks
-      model: 'claude-sonnet-4-5-20250929'
+      model: 'claude-sonnet-4-6'
       # Fail if plugin versions aren't bumped
       fail_on_missing_version: true
       # Fail if documentation is not updated

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,12 +47,12 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@824dfc19f7c2eecc5b12f6ae7b8fccdb92433ca4
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      # Use default model (claude-sonnet-4-5-20250929)
+      # Use default model (claude-sonnet-4-6)
       # Use default timeout (15 minutes)
       # Use default prompt from ai-toolkit
       commit_history_count: 30


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.133` (`787c5a0`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133
- **ai-toolkit reusable workflows:** `824dfc1` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-7`
  - `sonnet` → `claude-sonnet-4-6`

### Per-file changes

#### `.github/workflows/claude-code-review.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `83ac42b` → `824dfc1`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `83ac42b` → `824dfc1`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `83ac42b` → `824dfc1`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`

#### `.github/workflows/claude-docs-check.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml`: `83ac42b` → `824dfc1`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`

#### `.github/workflows/generate-pr-title-description.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `83ac42b` → `824dfc1`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`



_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:
- **claude-code-action:** `v1.0.133` (`787c5a0`) — see <https://github.com/anthropics/claude-code-action/releases/tag/v1.0.133>
- **ai-toolkit reusable workflows:** `824dfc1` (Uniswap/ai-toolkit `next` HEAD)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-4-7`
  - `sonnet` → `claude-sonnet-4-6`
### Per-file changes
#### `.github/workflows/claude-code-review.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml`: `83ac42b` → `824dfc1` (×3 callers)
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6` (×3 callers)
#### `.github/workflows/claude-docs-check.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml`: `83ac42b` → `824dfc1`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
#### `.github/workflows/generate-pr-title-description.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `83ac42b` → `824dfc1`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
---
_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._

</details>
<!-- claude-pr-description-end -->