### PR TITLE
chore(deps): update ai-toolkit reusable workflow SHAs to 6d35d60

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -219,7 +219,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -270,7 +270,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -302,7 +302,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -219,7 +219,7 @@ jobs:
         github.event.pull_request.user.login == 'claude[bot]'
       )
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
@@ -270,7 +270,7 @@ jobs:
       github.event_name == 'workflow_dispatch' &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}
@@ -302,7 +302,7 @@ jobs:
       (github.event_name == 'issue_comment' || github.event_name == 'pull_request_review_comment') &&
       needs.get-pr-info.outputs.should_run == 'true'
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-code-review.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       pr_number: ${{ needs.get-pr-info.outputs.pr_number }}
       base_ref: ${{ needs.get-pr-info.outputs.base_ref }}

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}

--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,7 +54,7 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@6d35d60ab7805aefae2837776d870787d93c8a18 # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,7 +47,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@6d35d60ab7805aefae2837776d870787d93c8a18
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,7 +47,7 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@83ac42bf6a63fdaa2fc71c760b02ab85df21068a
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@f43e9a271d5980407bd3a375b9ed0394f79e7f3d
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Automated update of `Uniswap/ai-toolkit` reusable workflow SHA references.

**Updated to:** `f43e9a271d5980407bd3a375b9ed0394f79e7f3d`

### Recent ai-toolkit changes

- chore(slack-oauth-backend): log OAuth request and Slack-granted scopes (#520)
- chore(sync): [skip ci] sync next with main
- fix(slack-oauth-backend): drop incoming-webhook bot scope (#518)
- feat(slack-oauth-backend): expand OAuth scope requests to match app manifest (#517)
- Merge pull request #519 from Uniswap/fix/claude-author-identity

### Files updated

- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude-docs-check.yml`
- `.github/workflows/generate-pr-title-description.yml`


*Auto-created by ai-toolkit workflow sync task.*

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Automated update of `Uniswap/ai-toolkit` reusable workflow SHA references from `83ac42b` to `6d35d60`.
### Files updated
- `.github/workflows/claude-code-review.yml`
- `.github/workflows/claude-docs-check.yml`
- `.github/workflows/generate-pr-title-description.yml`
---
*Auto-created by ai-toolkit workflow sync task.*

</details>
<!-- claude-pr-description-end -->