### PR TITLE
chore(repo): ignore Claude Code session output directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,7 @@ package-lock.json
 .devenv/
 devenv.lock
 .npm-global/
+
+# Claude Code session outputs: screenshots, traces, ad-hoc reports. Never committed.
+.claude-outputs/
+.playwright-mcp/


### PR DESCRIPTION
Adds `.claude-outputs/` and `.playwright-mcp/` to the root .gitignore. These are local Claude Code session by-products (screenshots, traces, ad-hoc reports, Playwright MCP snapshots) that should never be committed.

Two-line change, no code impact.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Adds `.claude-outputs/` and `.playwright-mcp/` to the root `.gitignore` so local Claude Code session by-products (screenshots, traces, ad-hoc reports, Playwright MCP snapshots) are never committed.
## Changes
- Append two ignore patterns to `.gitignore` with a brief comment explaining the rationale
## Notes
Two-line change, no code impact.

</details>
<!-- claude-pr-description-end -->