### PR TITLE
chore(repo): ignore local-only tooling and draft files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,13 @@ devenv.lock
 # Claude Code session outputs: screenshots, traces, ad-hoc reports. Never committed.
 .claude-outputs/
 .playwright-mcp/
+
+# Local-only tooling and draft files (per-developer; not committed)
+.agents/
+.claude/launch.json
+.claude/skills/
+.serena/
+.spec-workflow/
+.x402-signer.mjs
+docs/proposals/
+docs/uniswap-ai-one-pager.pdf


### PR DESCRIPTION
Adds per-developer local tooling and draft paths to the root .gitignore so they stop showing in git status and are never committed:

- `.agents/`, `.serena/`, `.spec-workflow/` (local agent/MCP tooling)
- `.claude/launch.json`, `.claude/skills/` (local Claude Code config; `.claude/rules/` stays tracked)
- `.x402-signer.mjs` (local signer script)
- `docs/proposals/`, `docs/uniswap-ai-one-pager.pdf` (local drafts)

gitignore-only change, no code impact.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Adds per-developer local tooling and draft paths to the root `.gitignore` so they stop appearing in `git status` and are never accidentally committed. Pure `.gitignore` change with no code impact.
## Changes
- Append a new `Local-only tooling and draft files` block to `.gitignore` covering:
  - `.agents/`, `.serena/`, `.spec-workflow/` — local agent/MCP tooling directories
  - `.claude/launch.json`, `.claude/skills/` — local Claude Code config (note: `.claude/rules/` remains tracked)
  - `.x402-signer.mjs` — local signer script
  - `docs/proposals/`, `docs/uniswap-ai-one-pager.pdf` — local draft documents
## Notes
`.gitignore`-only change — no source, build, or CI behavior is affected.

</details>
<!-- claude-pr-description-end -->