### PR TITLE
fix(ci): unbreak eval suites and stop workflow reporting false green

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -192,9 +192,9 @@ environment before its first publish.
 `NODE_VERSION` must stay at or above the floor promptfoo declares in its
 `engines` field (`^20.20.0 || >=22.22.0`). It sat at `22.21.1` for a stretch, one
 patch under the floor, which aborted every eval suite at startup while the Evals
-workflow still reported success. It reads `22.22.1` as of 2026-07-31. Keep it in
-step with `.nvmrc`, and treat that floor as a constraint on any job that runs
-promptfoo.
+workflow still reported success. It reads `22.22.1` as of 2026-07-31. Raising
+this variable above the floor keeps all jobs compatible with promptfoo's runtime
+requirements. The preflight step below fails loudly on any future drift.
 
 ## Security
 

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -127,8 +127,8 @@ LLM-based evaluation of AI skills using [Promptfoo](https://github.com/promptfoo
 - Manual trigger supports: specific suite (`nx run eval-suite-<name>:eval`), skip cache, multi-model mode
 
 **Node version:** promptfoo refuses to start on a runtime outside its `engines`
-range (`^20.20.0 || >=22.22.0`), so this workflow pins Node literally rather than
-reading `vars.NODE_VERSION` (see [Repository Variables](#repository-variables)).
+range (`^20.20.0 || >=22.22.0`), so `vars.NODE_VERSION` has to stay at or above
+that floor (see [Repository Variables](#repository-variables)).
 
 **better-sqlite3 native binding:** installs use `--ignore-scripts` so a PR cannot
 get code execution out of this repo's own `prepare` script in a job that holds
@@ -189,11 +189,12 @@ environment before its first publish.
 | `NPM_VERSION`  | npm version for the publish job (11.7.0+, OIDC support) |
 | `BUN_VERSION`  | Bun version for CI (defaults to 1.3.13)                 |
 
-`NODE_VERSION` is currently `22.21.1`, which is **below** the floor promptfoo
-declares in its `engines` field (`^20.20.0 || >=22.22.0`). `evals.yml` therefore
-pins its own Node version literally instead of reading the variable. Raising the
-variable to match `.nvmrc` (`22.22.2`) would let `evals.yml` read it again.
-Anything else that runs promptfoo must stay at or above that floor.
+`NODE_VERSION` must stay at or above the floor promptfoo declares in its
+`engines` field (`^20.20.0 || >=22.22.0`). It sat at `22.21.1` for a stretch, one
+patch under the floor, which aborted every eval suite at startup while the Evals
+workflow still reported success. It reads `22.22.1` as of 2026-07-31. Keep it in
+step with `.nvmrc`, and treat that floor as a constraint on any job that runs
+promptfoo.
 
 ## Security
 

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -146,6 +146,17 @@ promptfoo's startup touches both the runtime check and the database, so this one
 cheap command fails the job immediately instead of letting the same abort repeat
 once per suite deep inside the Nx log.
 
+**Errored cases are gated separately from the pass rate.** promptfoo counts a case
+that never produced a verdict (rate limit, provider outage, broken suite config)
+as an `error`, not a `failure`. Errors land in neither side of the
+`successes / (successes + failures)` pass rate, so a suite where every case errors
+contributes `0` to both and drops out of the denominator completely. A full
+15-suite run hit exactly this: 31 rate-limited cases across three suites reported
+an 89.86% pass rate and a green job. The workflow now sums errors, shows them in
+the summary table, and fails on any non-zero count, so an incomplete measurement
+can never read as a good one. Rate-limit errors are the most likely cause when
+running many suites at once; re-run rather than lowering the threshold.
+
 **Distinguishing "no suites ran" from "every suite crashed":** the Nx invocation
 is deliberately `|| true`, because promptfoo also exits non-zero for ordinary
 assertion failures, which the ≥85% pass-rate threshold is what gates. That means

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -129,8 +129,22 @@ LLM-based evaluation of AI skills using [Promptfoo](https://github.com/promptfoo
 **Node version:** promptfoo refuses to start on a runtime outside its `engines`
 range (`^20.20.0 || >=22.22.0`), so this workflow pins Node literally rather than
 reading `vars.NODE_VERSION` (see [Repository Variables](#repository-variables)).
-A `Verify promptfoo can run on this Node` preflight step fails the job
-immediately if the runtime ever drifts back below that floor.
+
+**better-sqlite3 native binding:** installs use `--ignore-scripts` so a PR cannot
+get code execution out of this repo's own `prepare` script in a job that holds
+`ANTHROPIC_API_KEY`. That flag also suppresses builds for packages bun would
+otherwise trust by default, so promptfoo's `better-sqlite3` dependency arrives
+without its compiled binding and promptfoo dies in `getDb()` during startup. A
+`Build better-sqlite3 native binding` step builds that single package after
+install, which keeps `--ignore-scripts` in place. Removing the flag instead would
+fix the binding and reopen the script-execution hole, so prefer the targeted
+build.
+
+Both of the above are smoke-tested by a `Verify promptfoo can run on this Node`
+preflight that runs `promptfoo --version` before any suite is dispatched.
+promptfoo's startup touches both the runtime check and the database, so this one
+cheap command fails the job immediately instead of letting the same abort repeat
+once per suite deep inside the Nx log.
 
 **Distinguishing "no suites ran" from "every suite crashed":** the Nx invocation
 is deliberately `|| true`, because promptfoo also exits non-zero for ordinary

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -126,6 +126,22 @@ LLM-based evaluation of AI skills using [Promptfoo](https://github.com/promptfoo
 - Aggregates pass/fail across affected suites; requires ≥85% pass rate
 - Manual trigger supports: specific suite (`nx run eval-suite-<name>:eval`), skip cache, multi-model mode
 
+**Node version:** promptfoo refuses to start on a runtime outside its `engines`
+range (`^20.20.0 || >=22.22.0`), so this workflow pins Node literally rather than
+reading `vars.NODE_VERSION` (see [Repository Variables](#repository-variables)).
+A `Verify promptfoo can run on this Node` preflight step fails the job
+immediately if the runtime ever drifts back below that floor.
+
+**Distinguishing "no suites ran" from "every suite crashed":** the Nx invocation
+is deliberately `|| true`, because promptfoo also exits non-zero for ordinary
+assertion failures, which the ≥85% pass-rate threshold is what gates. That means
+Nx's exit code cannot tell a crash from a low score. So the workflow enumerates
+the suites Nx will select (`nx show projects`) before running them, and fails if
+any selected suite produced no `results.json`. A suite that wrote no output died
+before it could be scored, which is an infrastructure failure rather than a low
+score. Without that comparison, a run where every suite crashed looks exactly
+like a run where no suite was affected, and the job reports success.
+
 ### GitHub Actions Analysis
 
 **File:** `zizmor.yml`
@@ -158,6 +174,12 @@ environment before its first publish.
 | `NODE_VERSION` | Node.js version for CI (22.x)                           |
 | `NPM_VERSION`  | npm version for the publish job (11.7.0+, OIDC support) |
 | `BUN_VERSION`  | Bun version for CI (defaults to 1.3.13)                 |
+
+`NODE_VERSION` is currently `22.21.1`, which is **below** the floor promptfoo
+declares in its `engines` field (`^20.20.0 || >=22.22.0`). `evals.yml` therefore
+pins its own Node version literally instead of reading the variable. Raising the
+variable to match `.nvmrc` (`22.22.2`) would let `evals.yml` read it again.
+Anything else that runs promptfoo must stay at or above that floor.
 
 ## Security
 

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -216,6 +216,7 @@ jobs:
           # Aggregate results from suites that produced output
           TOTAL_PASS=0
           TOTAL_FAIL=0
+          TOTAL_ERROR=0
           TOTAL_COST=0
           RESULTS_SUMMARY=""
           SUITES_RAN=0
@@ -226,14 +227,21 @@ jobs:
 
             PASS=$(jq '.results.stats.successes // 0' "$results_file")
             FAIL=$(jq '.results.stats.failures // 0' "$results_file")
+            # promptfoo counts a case that never produced a verdict (rate limit,
+            # provider outage, bad config) as an error, not a failure. Errors are
+            # deliberately excluded from the pass rate below and gated
+            # separately, because a percentage over an incomplete sample reads as
+            # a quality signal when it is really a measurement gap.
+            ERROR=$(jq '.results.stats.errors // 0' "$results_file")
             COST=$(jq '.results.stats.totalCost // 0' "$results_file")
 
             TOTAL_PASS=$((TOTAL_PASS + PASS))
             TOTAL_FAIL=$((TOTAL_FAIL + FAIL))
+            TOTAL_ERROR=$((TOTAL_ERROR + ERROR))
             TOTAL_COST=$(echo "$TOTAL_COST + $COST" | bc -l)
             SUITES_RAN=$((SUITES_RAN + 1))
 
-            RESULTS_SUMMARY="${RESULTS_SUMMARY}| ${suite_name} | ${PASS} | ${FAIL} | \$${COST} |\n"
+            RESULTS_SUMMARY="${RESULTS_SUMMARY}| ${suite_name} | ${PASS} | ${FAIL} | ${ERROR} | \$${COST} |\n"
           done
 
           if [ "$SUITES_RAN" -eq 0 ]; then
@@ -258,17 +266,22 @@ jobs:
           # Output summary
           echo "## Eval Results" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "| Suite | Passed | Failed | Cost |" >> "$GITHUB_STEP_SUMMARY"
-          echo "|-------|--------|--------|------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Suite | Passed | Failed | Errored | Cost |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|--------|---------|------|" >> "$GITHUB_STEP_SUMMARY"
           echo -e "$RESULTS_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
-          echo "| **Total** | **$TOTAL_PASS** | **$TOTAL_FAIL** | **\$${TOTAL_COST}** |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Total** | **$TOTAL_PASS** | **$TOTAL_FAIL** | **$TOTAL_ERROR** | **\$${TOTAL_COST}** |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Pass Rate:** ${PASS_RATE}% ($SUITES_RAN of $SELECTED_COUNT selected suite(s) evaluated)" >> "$GITHUB_STEP_SUMMARY"
+          if [ "$TOTAL_ERROR" -gt 0 ]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "⚠️ ${TOTAL_ERROR} case(s) errored and produced no verdict, so the pass rate above covers an incomplete sample." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           # Set outputs
           echo "pass_rate=$PASS_RATE" >> "$GITHUB_OUTPUT"
           echo "total_pass=$TOTAL_PASS" >> "$GITHUB_OUTPUT"
           echo "total_fail=$TOTAL_FAIL" >> "$GITHUB_OUTPUT"
+          echo "total_error=$TOTAL_ERROR" >> "$GITHUB_OUTPUT"
           echo "total_cost=$TOTAL_COST" >> "$GITHUB_OUTPUT"
 
           # A selected suite that wrote no results.json died before producing
@@ -277,6 +290,18 @@ jobs:
           # instead of reporting a pass rate for the subset that survived.
           if [ "$SUITES_RAN" -lt "$SELECTED_COUNT" ]; then
             echo "::error::Only ${SUITES_RAN} of ${SELECTED_COUNT} selected eval suite(s) produced results.json. The rest failed before writing output. See the Nx output above."
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
+
+          # An errored case produced no verdict, so it lands in neither
+          # TOTAL_PASS nor TOTAL_FAIL and is invisible to the pass rate. A suite
+          # where every case errors contributes 0 to both and disappears from the
+          # denominator entirely, which is how 31 rate-limited cases across three
+          # suites once reported an 89.86% pass and a green job. Gate on errors
+          # separately so an incomplete measurement can never read as a good one.
+          if [ "$TOTAL_ERROR" -gt 0 ]; then
+            echo "::error::${TOTAL_ERROR} eval case(s) errored and produced no verdict, so the ${PASS_RATE}% pass rate covers an incomplete sample. Errors are infrastructure failures (rate limits, provider outages, broken suite config) rather than low scores. See the Nx output above."
             echo "status=failed" >> "$GITHUB_OUTPUT"
             exit 1
           fi
@@ -315,12 +340,14 @@ jobs:
           PASS_RATE: ${{ steps.eval.outputs.pass_rate }}
           TOTAL_PASS: ${{ steps.eval.outputs.total_pass }}
           TOTAL_FAIL: ${{ steps.eval.outputs.total_fail }}
+          TOTAL_ERROR: ${{ steps.eval.outputs.total_error }}
           TOTAL_COST: ${{ steps.eval.outputs.total_cost }}
         with:
           script: |
             const passRate = process.env.PASS_RATE;
             const totalPass = process.env.TOTAL_PASS;
             const totalFail = process.env.TOTAL_FAIL;
+            const totalError = process.env.TOTAL_ERROR;
             const totalCost = process.env.TOTAL_COST;
 
             const body = `## Eval Results
@@ -330,6 +357,7 @@ jobs:
             | Pass Rate | ${passRate}% |
             | Passed | ${totalPass} |
             | Failed | ${totalFail} |
+            | Errored | ${totalError} |
             | Inference Cost | $${totalCost} |
 
             [View full results](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -70,16 +70,15 @@ jobs:
       # (.npmrc, bunfig.toml) in the PR cannot influence tool installation.
       # Note: secrets like ANTHROPIC_API_KEY are not passed to fork PRs by
       # GitHub default; this is defense-in-depth for same-repo PRs.
-      # Pinned literally rather than read from vars.NODE_VERSION: promptfoo
-      # refuses to start on a runtime outside its `engines` range
-      # (^20.20.0 || >=22.22.0), and that repo variable is 22.21.1, which is
-      # below the floor and killed every suite. Keep this in sync with .nvmrc;
-      # .nvmrc cannot be used here because checkout deliberately runs after
-      # tool setup. The preflight step below fails loudly on any future drift.
+      # vars.NODE_VERSION has to stay at or above promptfoo's `engines` floor
+      # (^20.20.0 || >=22.22.0). It sat at 22.21.1 for a stretch, one patch
+      # under, which aborted every suite at startup. The '22' fallback is safe
+      # because setup-node resolves it to the latest 22.x. The preflight step
+      # below fails loudly if the variable ever drifts back under the floor.
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '22.22.2'
+          node-version: ${{ vars.NODE_VERSION || '22' }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -70,10 +70,16 @@ jobs:
       # (.npmrc, bunfig.toml) in the PR cannot influence tool installation.
       # Note: secrets like ANTHROPIC_API_KEY are not passed to fork PRs by
       # GitHub default; this is defense-in-depth for same-repo PRs.
+      # Pinned literally rather than read from vars.NODE_VERSION: promptfoo
+      # refuses to start on a runtime outside its `engines` range
+      # (^20.20.0 || >=22.22.0), and that repo variable is 22.21.1, which is
+      # below the floor and killed every suite. Keep this in sync with .nvmrc;
+      # .nvmrc cannot be used here because checkout deliberately runs after
+      # tool setup. The preflight step below fails loudly on any future drift.
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: ${{ vars.NODE_VERSION || '22' }}
+          node-version: '22.22.2'
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -91,6 +97,16 @@ jobs:
         # postinstall RCE (Shai-Hulud class). Eval workflow handles secrets
         # (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN) for same-repo PRs.
         run: bun install --frozen-lockfile --ignore-scripts
+
+      # promptfoo aborts on an unsupported Node runtime. Without this preflight
+      # that abort is repeated once per suite deep inside the Nx log while the
+      # job still reports success, which is how an every-suite outage went
+      # unnoticed. `--version` exercises the same guard for free and offline.
+      - name: Verify promptfoo can run on this Node
+        working-directory: evals
+        env:
+          PROMPTFOO_DISABLE_UPDATE: '1'
+        run: bunx promptfoo --version
 
       - name: Restore Nx cache
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -114,6 +130,17 @@ jobs:
           command -v jq >/dev/null 2>&1 || { echo "::error::jq is required but not installed"; exit 1; }
           command -v bc >/dev/null 2>&1 || { echo "::error::bc is required but not installed"; exit 1; }
 
+          # Validate suite input before it reaches Nx (only alphanumeric, dash,
+          # and underscore allowed)
+          if [ -n "$SUITE_INPUT" ] && ! echo "$SUITE_INPUT" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+            echo "::error::Invalid suite name. Only alphanumeric, dash, and underscore allowed"
+            exit 1
+          fi
+
+          nx_cli() {
+            bunx --package=nx@22.0.2 nx "$@"
+          }
+
           # Build skip-cache flag
           NX_CACHE_FLAG=""
           if [ "$SKIP_CACHE" = "true" ]; then
@@ -124,30 +151,43 @@ jobs:
           # Clear previous results so aggregation only counts suites that ran
           rm -f evals/suites/*/results.json
 
+          # Enumerate the suites Nx will select, before running them. A suite
+          # that dies before writing results.json is otherwise indistinguishable
+          # from a suite that was never selected, so the aggregation below would
+          # report "nothing affected" and pass. Nx's exit code cannot stand in
+          # for this: promptfoo also exits non-zero for ordinary assertion
+          # failures, which the pass-rate threshold is what handles.
+          if [ -n "$SUITE_INPUT" ]; then
+            SELECTED="eval-suite-$SUITE_INPUT"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            SELECTED=$(nx_cli show projects -t eval --projects='tag:type:eval-suite' 2>/dev/null)
+          else
+            SELECTED=$(nx_cli show projects --affected -t eval --exclude=evals 2>/dev/null)
+          fi
+          # awk, not `grep -c`: grep exits 1 on no match, which would abort this
+          # step under `bash -e` on the legitimate zero-suite path.
+          SELECTED_COUNT=$(printf '%s\n' "$SELECTED" | awk 'NF{n++} END{print n+0}')
+          echo "::notice::${SELECTED_COUNT} eval suite(s) selected"
+
           # Run eval suites via Nx
           # - PR: nx affected uses the project graph to run only suites whose
           #   plugin or eval dependencies changed (defaultBase: origin/main)
           # - Manual (specific suite): nx run targets the exact suite
           # - Manual (all): nx run-many runs all eval-suite-* projects
           if [ -n "$SUITE_INPUT" ]; then
-            # Validate suite input (only alphanumeric, dash, and underscore allowed)
-            if ! echo "$SUITE_INPUT" | grep -qE '^[a-zA-Z0-9_-]+$'; then
-              echo "::error::Invalid suite name. Only alphanumeric, dash, and underscore allowed"
-              exit 1
-            fi
             echo "::group::Running specific suite: $SUITE_INPUT"
             # shellcheck disable=SC2086
-            bunx --package=nx@22.0.2 nx run "eval-suite-$SUITE_INPUT:eval" $NX_CACHE_FLAG || true
+            nx_cli run "eval-suite-$SUITE_INPUT:eval" $NX_CACHE_FLAG || true
             echo "::endgroup::"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "::group::Running all eval suites (manual trigger)"
             # shellcheck disable=SC2086
-            bunx --package=nx@22.0.2 nx run-many -t eval --projects='tag:type:eval-suite' $NX_CACHE_FLAG || true
+            nx_cli run-many -t eval --projects='tag:type:eval-suite' $NX_CACHE_FLAG || true
             echo "::endgroup::"
           else
             echo "::group::Running affected eval suites"
             # shellcheck disable=SC2086
-            bunx --package=nx@22.0.2 nx affected -t eval --exclude=evals $NX_CACHE_FLAG || true
+            nx_cli affected -t eval --exclude=evals $NX_CACHE_FLAG || true
             echo "::endgroup::"
           fi
 
@@ -175,6 +215,11 @@ jobs:
           done
 
           if [ "$SUITES_RAN" -eq 0 ]; then
+            if [ "$SELECTED_COUNT" -gt 0 ]; then
+              echo "::error::All ${SELECTED_COUNT} selected eval suite(s) failed before writing results.json. See the Nx output above."
+              echo "status=failed" >> "$GITHUB_OUTPUT"
+              exit 1
+            fi
             echo "No eval suites were affected"
             echo "status=skipped" >> "$GITHUB_OUTPUT"
             exit 0
@@ -196,13 +241,23 @@ jobs:
           echo -e "$RESULTS_SUMMARY" >> "$GITHUB_STEP_SUMMARY"
           echo "| **Total** | **$TOTAL_PASS** | **$TOTAL_FAIL** | **\$${TOTAL_COST}** |" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Pass Rate:** ${PASS_RATE}% ($SUITES_RAN suite(s) evaluated)" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Pass Rate:** ${PASS_RATE}% ($SUITES_RAN of $SELECTED_COUNT selected suite(s) evaluated)" >> "$GITHUB_STEP_SUMMARY"
 
           # Set outputs
           echo "pass_rate=$PASS_RATE" >> "$GITHUB_OUTPUT"
           echo "total_pass=$TOTAL_PASS" >> "$GITHUB_OUTPUT"
           echo "total_fail=$TOTAL_FAIL" >> "$GITHUB_OUTPUT"
           echo "total_cost=$TOTAL_COST" >> "$GITHUB_OUTPUT"
+
+          # A selected suite that wrote no results.json died before producing
+          # output (unusable runtime, broken config, missing credentials). That
+          # is an infrastructure failure rather than a low score, so fail on it
+          # instead of reporting a pass rate for the subset that survived.
+          if [ "$SUITES_RAN" -lt "$SELECTED_COUNT" ]; then
+            echo "::error::Only ${SUITES_RAN} of ${SELECTED_COUNT} selected eval suite(s) produced results.json. The rest failed before writing output. See the Nx output above."
+            echo "status=failed" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
           # Fail if below threshold (85%)
           if [ "$TOTAL" -gt 0 ]; then

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -98,10 +98,33 @@ jobs:
         # (ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN) for same-repo PRs.
         run: bun install --frozen-lockfile --ignore-scripts
 
-      # promptfoo aborts on an unsupported Node runtime. Without this preflight
-      # that abort is repeated once per suite deep inside the Nx log while the
-      # job still reports success, which is how an every-suite outage went
-      # unnoticed. `--version` exercises the same guard for free and offline.
+      # `--ignore-scripts` also suppresses builds for packages bun would
+      # otherwise trust by default, so promptfoo's better-sqlite3 dependency
+      # lands without its native binding and promptfoo dies in getDb() during
+      # startup. Build that one package instead of dropping --ignore-scripts,
+      # which would also execute this repo's own PR-controlled `prepare` script
+      # in a job that holds ANTHROPIC_API_KEY. better-sqlite3's install script
+      # is `prebuild-install || node-gyp rebuild --release`, so it fetches a
+      # prebuilt binary when egress allows it and compiles from source if not.
+      - name: Build better-sqlite3 native binding
+        run: |
+          bs3_dir=$(echo node_modules/.bun/better-sqlite3@*/node_modules/better-sqlite3)
+          if [ ! -d "$bs3_dir" ]; then
+            echo "::error::Expected exactly one better-sqlite3 under node_modules/.bun, got '$bs3_dir'. If bun changed its store layout, update this step."
+            exit 1
+          fi
+          (cd "$bs3_dir" && bun run install)
+          if [ ! -f "$bs3_dir/build/Release/better_sqlite3.node" ]; then
+            echo "::error::better-sqlite3 produced no native binding, so promptfoo cannot open its database."
+            exit 1
+          fi
+
+      # Smoke-test promptfoo's startup path before handing it 16 suites: it
+      # aborts on an unsupported Node runtime and also on a missing
+      # better-sqlite3 binding. Without this, either abort is repeated once per
+      # suite deep inside the Nx log while the job still reports success, which
+      # is how an every-suite outage went unnoticed. `--version` exercises both
+      # guards for free and without network access.
       - name: Verify promptfoo can run on this Node
         working-directory: evals
         env:


### PR DESCRIPTION
## Summary

Every eval suite has been failing to start in CI, and the Evals workflow has been
reporting success anyway. There were **two stacked runtime defects** plus the
reporting bug that hid them. All three are fixed here.

### Defect 1: Node below promptfoo's floor

`bun.lock` pins promptfoo `0.121.11`, which declares
`"engines": { "node": "^20.20.0 || >=22.22.0" }` and hard-aborts outside it. The
`NODE_VERSION` repository variable is `22.21.1`, one patch below the floor, and
`evals.yml` read it via `vars.NODE_VERSION`:

```
promptfoo requires a supported Node.js runtime.
Detected: v22.21.1
Required: ^20.20.0 || >=22.22.0
```

All 16 suites in [run 30657558713](https://github.com/Uniswap/uniswap-ai/actions/runs/30657558713)
died this way. The variable has since been raised to `22.22.1`, which clears
the floor, so this PR leaves `node-version: ${{ vars.NODE_VERSION || '22' }}`
exactly as it is on main. It documents the constraint in a comment and enforces it
with the preflight step described under defect 3, so a future drift back under the
floor fails the job immediately instead of silently.

### Defect 2: better-sqlite3 has no native binding

Fixing the Node version uncovered a second failure the abort had been hiding.
promptfoo opens a SQLite database during startup and crashed with
`Could not locate the bindings file` in `getDb()`.

Installs use `bun install --frozen-lockfile --ignore-scripts`, and in bun that
flag also suppresses lifecycle scripts for packages bun would otherwise trust by
default. `better-sqlite3` is one of them (confirmed: it is in
`bun pm default-trusted`), and its install script is what produces the native
binding.

Fixed by building that one package after install rather than dropping
`--ignore-scripts`. **The flag is load-bearing**: without it bun also runs this
repo's own `prepare` script, which a PR controls, in the one job holding
`ANTHROPIC_API_KEY`. Two tidier alternatives were tried and rejected on evidence:

- `bun pm trust better-sqlite3` runs 0 scripts, because bun considers the package
  already trusted via its default list.
- `require.resolve('promptfoo/package.json')` throws, so the package cannot be
  located that way. The bun store path is globbed instead, and the step fails
  loudly if the glob matches anything other than one directory.

### Defect 3: the workflow reported success through all of it

The Nx invocation is `|| true` on purpose, since promptfoo also exits non-zero for
ordinary assertion failures and the >=85% pass-rate threshold is what gates those.
But with the exit code discarded, zero `results.json` files were
indistinguishable from "no suites were affected", so the job took the skip path
and exited 0:

```bash
if [ "$SUITES_RAN" -eq 0 ]; then
  echo "No eval suites were affected"
  echo "status=skipped" >> "$GITHUB_OUTPUT"
  exit 0          # <- every suite crashed, job passes
fi
```

The workflow now enumerates the suites Nx will select (`nx show projects`) before
running them and fails when a selected suite produced no `results.json`, since a
suite that wrote no output died before it could be scored. Assertion-failure exit
codes still flow through the pass-rate threshold untouched. A
`Verify promptfoo can run on this Node` preflight additionally smoke-tests
promptfoo's startup path once, up front, instead of letting the same abort repeat
once per suite deep in the Nx log.

## Test plan

**Verified in real CI on this branch.** Dispatch run
[30659645932](https://github.com/Uniswap/uniswap-ai/actions/runs/30659645932) ran
the `swap-planner` suite end to end:

```
$ prebuild-install || node-gyp rebuild --release   <- native binding built
##[notice]1 eval suite(s) selected                 <- suite enumeration works
2 passed (66.67%), 1 failed, 0 errors              <- promptfoo actually ran
##[error]Pass rate 66.66% is below 85% threshold   <- score gate fires
```

That run **failed, and failing is the correct outcome**. The suite executed to
completion, wrote `results.json`, and reported 2 passed / 1 failed / **0 errors**,
so the crash detector correctly stayed quiet and the 85% threshold did the gating.
The one failing case is genuine eval content, an assertion expecting the output to
contain `app.uniswap.org` or `uniswap.org`, not an infrastructure problem. It has
simply been invisible for the two and a half months the suites could not start.

The PR's own eval run passes, exercising the preflight and the zero-suite skip
path. On the intermediate commit the preflight also proved its worth by failing
the run loudly on the better-sqlite3 defect instead of hiding it.

**Heads up on merging:** this restores a gate that has been vacuous since
2026-05-15. PRs touching `packages/plugins/**` will start running real evals again
and can fail on real scores. `swap-planner` is at 66.67% today; I have not measured
the other 14 suites, so some may also sit below 85% and need content work. That is
eval quality rather than CI breakage, so it is deliberately not addressed here.

**Reproduced locally against the real pinned dependency:**

- promptfoo `0.121.11` on Node `22.21.1` reproduces the runtime abort
  byte-for-byte against the CI log, exit 1.
- On Node `22.22.2` it starts, and `promptfoo validate` reports the suite config valid.
- Removing the `better_sqlite3.node` binding reproduces the exact CI bindings
  error; `bun run install` in the globbed package directory restores it and
  promptfoo starts cleanly.

**Step-script logic**, exercised against a stubbed Nx across every path that
decides pass or fail (7/7):

| Scenario | Expected | Result |
| --- | --- | --- |
| Nothing selected | pass, `status=skipped` | pass |
| All selected suites crash | **fail** (was silently green) | fail |
| Partial crash (1 of 3 wrote results) | **fail** | fail |
| All ran, 90% pass, Nx exit non-zero | pass, `status=success` | pass |
| All ran, 50% pass | fail on threshold | fail |
| Single-suite dispatch crashes | **fail** | fail |
| Malformed suite input | rejected | rejected |

That harness also caught a bug before it shipped: counting selected suites with
`grep -c` aborts the step under `bash -e` on the legitimate zero-suite path, so
the code uses `awk` instead.

**Repo gates:** `nx format:check` clean, `markdownlint` 0 errors,
`validate-docs.cjs` passed, `zizmor` no findings, `actionlint` identical to base
(2 pre-existing SC2129 style notes, none new).

## Notes for the reviewer

- `nx affected` selects no suites for this PR since it touches only workflow
  files, so the PR's own eval job exercises the preflight and the zero-suite skip
  path. End-to-end suite execution was verified via the dispatch run above.
- The `generate-metadata` and `claude-review-auto` checks fail on this PR, but
  they fail identically on #120 and #121 and are unrelated to evals. They break in
  the shared workflow's `Run Claude Code Generation` step. Not diagnosed here.

## Follow-up, not in this PR

`.nvmrc` is `22.22.2` while `NODE_VERSION` is `22.22.1`. Both clear promptfoo's
floor, so nothing is broken, but setting the variable to `22.22.2` would make the
two agree exactly.

`swap-planner` scores 66.67% today. Whichever other suites also sit below 85% will
need content work now that the gate actually runs. That is tracked separately from
this CI fix.

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

## Summary
Every eval suite has been failing to start in CI, and the Evals workflow has been
reporting success anyway. There were **two stacked runtime defects** plus a
reporting bug that hid them and a fourth defect where rate-limited (errored)
cases silently dropped out of the pass rate. All four are fixed here.
### Defect 1: Node below promptfoo's floor
`bun.lock` pins promptfoo `0.121.11`, which declares
`"engines": { "node": "^20.20.0 || >=22.22.0" }` and hard-aborts outside it. The
`NODE_VERSION` repository variable was `22.21.1`, one patch below the floor, so
every suite died at startup:
```
promptfoo requires a supported Node.js runtime.
Detected: v22.21.1
Required: ^20.20.0 || >=22.22.0
```
All 16 suites in [run 30657558713](https://github.com/Uniswap/uniswap-ai/actions/runs/30657558713)
died this way. `NODE_VERSION` has since been raised to `22.22.1`, so `evals.yml`
reads `vars.NODE_VERSION` again with a `'22'` fallback (setup-node resolves that
to the latest 22.x, keeping the job above the floor even if the variable ever
drifts back under it). The preflight step below fails loudly if a runtime under
promptfoo's floor ever slips through.
### Defect 2: better-sqlite3 has no native binding
Fixing the Node version uncovered a second failure the abort had been hiding.
promptfoo opens a SQLite database during startup and crashed with
`Could not locate the bindings file` in `getDb()`.
Installs use `bun install --frozen-lockfile --ignore-scripts`, and that flag
also suppresses lifecycle scripts for packages bun would otherwise trust by
default. `better-sqlite3` is one of them (confirmed: it is in
`bun pm default-trusted`), and its install script is what produces the native
binding.
Fixed by building that one package after install rather than dropping
`--ignore-scripts`. **The flag is load-bearing**: without it bun also runs this
repo's own `prepare` script, which a PR controls, in the one job holding
`ANTHROPIC_API_KEY`. Two tidier alternatives were tried and rejected on
evidence:
- `bun pm trust better-sqlite3` runs 0 scripts, because bun considers the
  package already trusted via its default list.
- `require.resolve('promptfoo/package.json')` throws, so the package cannot be
  located that way. The bun store path is globbed instead, and the step fails
  loudly if the glob matches anything other than one directory.
### Defect 3: the workflow reported success through all of it
The Nx invocation is `|| true` on purpose, since promptfoo also exits non-zero
for ordinary assertion failures and the ≥85% pass-rate threshold is what gates
those. But with the exit code discarded, zero `results.json` files were
indistinguishable from "no suites were affected", so the job took the skip path
and exited 0:
```bash
if [ "$SUITES_RAN" -eq 0 ]; then
  echo "No eval suites were affected"
  echo "status=skipped" >> "$GITHUB_OUTPUT"
  exit 0          # <- every suite crashed, job passes
fi
```
The workflow now enumerates the suites Nx will select (`nx show projects`)
before running them and fails when a selected suite produced no `results.json`,
since a suite that wrote no output died before it could be scored.
Assertion-failure exit codes still flow through the pass-rate threshold
untouched. A `Verify promptfoo can run on this Node` preflight additionally
smoke-tests promptfoo's startup path once, up front, instead of letting the
same abort repeat once per suite deep in the Nx log.
### Defect 4: errored cases silently dropped out of the pass rate
promptfoo counts a case that never produced a verdict (rate limit, provider
outage, broken suite config) as an `error`, not a `failure`. Errors land in
neither side of `successes / (successes + failures)`, so a suite where every
case errors contributes `0` to both and disappears from the denominator
entirely. A full 15-suite run hit exactly this: 31 rate-limited cases across
three suites reported an 89.86% pass rate and a green job.
The workflow now sums errors, shows them in the summary table and PR comment,
and fails on any non-zero count. Rate-limit errors are the most likely cause
when running many suites at once; re-run rather than lowering the threshold.
## Changes
- `.github/workflows/evals.yml`
  - Add a `Build better-sqlite3 native binding` step that runs `bun run install`
    in the single `better-sqlite3` package under `node_modules/.bun/`, verifies
    the `.node` binding file exists, and keeps `--ignore-scripts` in place for
    the rest of the tree.
  - Add a `Verify promptfoo can run on this Node` preflight step
    (`bunx promptfoo --version`) that fails the job immediately on any future
    runtime or native-binding regression, before the Nx layer buries the error.
  - Enumerate the suites Nx will select up front via `nx show projects` and
    compare against the number that produced `results.json`; fail loudly on any
    shortfall instead of taking the zero-suite skip path or reporting a pass
    rate for the survivors.
  - Sum `results.stats.errors` across suites, surface it in the summary table
    and PR comment, and fail the job on any non-zero error count so an
    incomplete measurement can never read as a pass.
  - Hoist the suite-name input validation above the branch dispatch and factor
    the pinned `bunx --package=nx@22.0.2 nx` invocation into a single
    `nx_cli()` helper used everywhere.
  - Include the selected-vs-ran counts in the job step summary.
- `.github/workflows/CLAUDE.md`
  - Document the `NODE_VERSION` floor, the targeted `better-sqlite3` build, the
    preflight step, the selected-vs-ran comparison, and the errored-case gate
    under the Evals section.
  - Flag under Repository Variables that `NODE_VERSION` must stay at or above
    promptfoo's `engines` floor (`^20.20.0 || >=22.22.0`).
## Test plan
**Verified in real CI on this branch.** Dispatch run
[30659645932](https://github.com/Uniswap/uniswap-ai/actions/runs/30659645932)
ran the `swap-planner` suite end to end:
```
$ prebuild-install || node-gyp rebuild --release   <- native binding built
##[notice]1 eval suite(s) selected                 <- suite enumeration works
2 passed (66.67%), 1 failed, 0 errors              <- promptfoo actually ran
##[error]Pass rate 66.66% is below 85% threshold   <- score gate fires
```
That run **failed, and failing is the correct outcome**. The suite executed to
completion, wrote `results.json`, and reported 2 passed / 1 failed /
**0 errors**, so the crash detector correctly stayed quiet and the 85%
threshold did the gating. The one failing case is genuine eval content, an
assertion expecting the output to contain `app.uniswap.org` or `uniswap.org`,
not an infrastructure problem. It has simply been invisible for the two and a
half months the suites could not start.
The PR's own eval run passes, exercising the preflight and the zero-suite skip
path. On the intermediate commit the preflight also proved its worth by
failing the run loudly on the `better-sqlite3` defect instead of hiding it.
**Heads up on merging:** this restores a gate that has been vacuous since
2026-05-15. PRs touching `packages/plugins/**` will start running real evals
again and can fail on real scores or errored cases. `swap-planner` is at
66.67% today; I have not measured the other 14 suites, so some may also sit
below 85% and need content work. That is eval quality rather than CI breakage,
so it is deliberately not addressed here.
**Reproduced locally against the real pinned dependency:**
- promptfoo `0.121.11` on Node `22.21.1` reproduces the runtime abort
  byte-for-byte against the CI log, exit 1.
- On Node `22.22.2` it starts, and `promptfoo validate` reports the suite
  config valid.
- Removing the `better_sqlite3.node` binding reproduces the exact CI bindings
  error; `bun run install` in the globbed package directory restores it and
  promptfoo starts cleanly.
**Step-script logic**, exercised against a stubbed Nx across every path that
decides pass or fail (7/7):
| Scenario | Expected | Result |
| --- | --- | --- |
| Nothing selected | pass, `status=skipped` | pass |
| All selected suites crash | **fail** (was silently green) | fail |
| Partial crash (1 of 3 wrote results) | **fail** | fail |
| All ran, 90% pass, Nx exit non-zero | pass, `status=success` | pass |
| All ran, 50% pass | fail on threshold | fail |
| Single-suite dispatch crashes | **fail** | fail |
| Malformed suite input | rejected | rejected |
That harness also caught a bug before it shipped: counting selected suites
with `grep -c` aborts the step under `bash -e` on the legitimate zero-suite
path, so the code uses `awk` instead.
**Repo gates:** `nx format:check` clean, `markdownlint` 0 errors,
`validate-docs.cjs` passed, `zizmor` no findings, `actionlint` identical to
base (2 pre-existing SC2129 style notes, none new).
## Notes for the reviewer
- `nx affected` selects no suites for this PR since it touches only workflow
  files, so the PR's own eval job exercises the preflight and the zero-suite
  skip path. End-to-end suite execution was verified via the dispatch run
  above.
- The `generate-metadata` and `claude-review-auto` checks fail on this PR, but
  they fail identically on other recent PRs and are unrelated to evals. They
  break in the shared workflow's `Run Claude Code Generation` step. Not
  diagnosed here.
## Follow-up, not in this PR
`.nvmrc` is `22.22.2` while `NODE_VERSION` is `22.22.1`. Both clear promptfoo's
floor, so nothing is broken, but setting the variable to `22.22.2` would make
the two agree exactly.
`swap-planner` scores 66.67% today. Whichever other suites also sit below 85%
will need content work now that the gate actually runs. That is tracked
separately from this CI fix.

</details>
<!-- claude-pr-description-end -->