### PR TITLE
fix(ci): detect cancellation with cancelled(), and stop asserting why

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -92,6 +92,59 @@ and every Dependabot PR, silently disabling auto-merge.
 - Use workflow_dispatch: `gh workflow run "Claude Code Review" -f pr_number=123`
   (`force_review` defaults true, which skips change detection)
 
+**Cancellation, and the three terminal states.** A push to a PR cancels the
+review already in flight for it, because reviewing code a newer push has
+already replaced spends budget on a stale answer. One concurrency group covers
+every trigger type, so a push can cancel a review a human just asked for by
+comment. That is deliberate: splitting the group per trigger would let two
+reviews run concurrently against the same sticky comment, and serialization is
+worth more.
+
+`cancel-in-progress` only fires for events that will actually produce a
+replacement review, so it mirrors the first clause of the `triage` gate rather
+than testing `github.event_name` alone:
+
+```yaml
+cancel-in-progress: >-
+  ${{ github.event_name == 'pull_request'
+  && github.event.pull_request.head.repo.fork == false
+  && (github.event.pull_request.draft == false
+  || github.event.action == 'ready_for_review'
+  || github.event.pull_request.user.login == 'claude[bot]') }}
+```
+
+Note this is **not** a bare `draft == false`, because this repo does review
+`claude[bot]` drafts. If you change the gate, change this predicate to match, or
+a push will start cancelling reviews that nothing replaces.
+
+A run therefore ends in one of **three** states, not two, and the finalization
+steps report each differently:
+
+| State              | Gate           | Trigger comment | Threaded reply      |
+| ------------------ | -------------- | --------------- | ------------------- |
+| review completed   | `!cancelled()` | 👀 → 👍         | ✅ **Reviewed**     |
+| review job errored | `!cancelled()` | 👀 → 👎         | ⚠ **Review failed** |
+| run cancelled      | `cancelled()`  | 👀 kept         | ⏹ **Cancelled**     |
+
+Cancellation is detected with the `cancelled()` status-check function, not by
+comparing `job.status` in bash. `job.status` is documented to be one of
+`success` / `failure` / `cancelled`, but nothing specifies that it interpolates
+to `cancelled` for a step of the job currently being cancelled, so a bash
+comparison against it would be an unverified assumption.
+
+**If you triggered a review by comment and it was cancelled**, your 👀 stays
+(the request was superseded, not rejected) and the threaded reply says so. On a
+push supersede the newer run picks it up automatically. On a manual cancel from
+the Actions UI, nothing follows, so comment `@request-claude-review` again. Two
+known rough edges on the manual-cancel path:
+
+- The sticky summary comment still shows its "Review running" placeholder. This
+  needs a CLI change and is tracked in
+  [Uniswap/internal-tools#155](https://github.com/Uniswap/internal-tools/issues/155).
+- If the run is cancelled while still **queued**, no job is allocated, so no
+  finalization step runs at all. Harmless, because `triage` never ran either, so
+  there is no 👀 or reply to leave stale.
+
 ### Claude Docs Check
 
 **File:** `claude-docs-check.yml`

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -76,13 +76,30 @@ concurrency:
   # asymmetric on purpose and has one consequence worth naming: a push CAN
   # cancel a review a human just asked for by comment. That is handled
   # rather than ignored, in the finalization steps at the end of the review
-  # job, which report `cancelled` as "superseded" instead of "failed".
+  # job, which report `cancelled` as its own terminal state rather than
+  # folding it into "failed".
   #
   # Deliberately ONE group across all trigger types, not one per type.
   # Splitting the group would stop pushes from cancelling comment runs, but
   # would then let two reviews run concurrently against the same sticky
   # comment. Serialization is worth more than avoiding the cancellation.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  #
+  # The predicate mirrors the first clause of the triage gate below, so a
+  # cancellation only happens for events that will actually produce a
+  # replacement review. A bare `github.event_name == 'pull_request'` also
+  # fired for pushes this repo refuses to review (a human's draft, a fork),
+  # cancelling a comment-triggered review that nothing then replaced. Note
+  # this repo DOES review claude[bot] drafts, so the draft test cannot be a
+  # bare `draft == false`.
+  #
+  # Folded scalar with continuation lines at matching indent, so YAML
+  # collapses this to one line before Actions parses the expression.
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request'
+    && github.event.pull_request.head.repo.fork == false
+    && (github.event.pull_request.draft == false
+    || github.event.action == 'ready_for_review'
+    || github.event.pull_request.user.login == 'claude[bot]') }}
 
 env:
   # vars.REVIEW_CLI_VERSION is the authoritative pin — set it in repo
@@ -379,8 +396,9 @@ jobs:
           bun-version: ${{ env.BUN_VERSION }}
 
       # Install first — same two reasons as in triage, and here the
-      # second one has teeth: the finalization steps at the bottom of
-      # this job run `if: always()` under `continue-on-error: true`. If
+      # second one has teeth: the finalization steps at the bottom of this
+      # job run on every terminal state (two gated `!cancelled()`, the
+      # third `cancelled()`) under `continue-on-error: true`. If
       # install ran after the guards below and a guard failed, those
       # steps would find `steps.install.outputs.bin` empty, silently
       # no-op, and a rejected trigger comment would keep its 👀 and
@@ -613,17 +631,20 @@ jobs:
           retention-days: 30
           overwrite: true
 
-      # Skipped when the job was CANCELLED. A push to the PR cancels an
-      # in-flight review (see `cancel-in-progress` above), and a cancelled
-      # run is not a failed one — the newer run is already starting. Leaving
-      # the 👀 in place is accurate in that case; overwriting it with ❌
-      # would tell the commenter their request failed when it was merely
-      # superseded.
-      - name: Update reaction (✅ / ❌) on comment trigger
+      # `!cancelled()` runs on success and failure but not cancellation,
+      # which is what we want: a cancelled run is not a failed one, so
+      # leaving the 👀 in place is accurate rather than overwriting it with 👎
+      # and telling the commenter their request broke.
+      #
+      # Gated by the status-check function, NOT by comparing `job.status` in
+      # bash. `job.status` is documented to be one of success / failure /
+      # cancelled, but nothing specifies that it interpolates to `cancelled`
+      # for a step of the job currently being cancelled, so a bash comparison
+      # against it is an unverified assumption.
+      - name: Update reaction (👍 / 👎) on comment trigger
         if: |
-          always() &&
-          needs.triage.outputs.comment_id != '' &&
-          job.status != 'cancelled'
+          !cancelled() &&
+          needs.triage.outputs.comment_id != ''
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -642,9 +663,11 @@ jobs:
             --reaction "$REACTION" \
             --clear-prior-ack
 
+      # Success and failure only. Cancellation is the step after this one,
+      # gated on `cancelled()` — see the note there.
       - name: Update threaded reply with terminal state
         if: |
-          always() &&
+          !cancelled() &&
           needs.triage.outputs.reply_id != ''
         continue-on-error: true
         env:
@@ -657,17 +680,50 @@ jobs:
           REVIEW_CLI: ${{ steps.install.outputs.bin }}
           BUN_CONFIG_FILE: /dev/null
         run: |
-          # Three terminal states, not two. `job.status` is one of success /
-          # failure / cancelled, and conflating cancelled with failure tells
-          # a commenter their request broke when a newer push simply
-          # superseded it.
           if [ "$OUTCOME" = "success" ]; then
             BODY="✅ **Reviewed** · [view run ↗](${RUN_URL}) · scroll up for the full summary."
-          elif [ "$OUTCOME" = "cancelled" ]; then
-            BODY="⏹ **Superseded** · a newer push to this PR started a fresh review, so this one was cancelled · [view run ↗](${RUN_URL})"
           else
             BODY="⚠ **Review failed** · [view run ↗](${RUN_URL}) · scroll up for the partial state, or comment \`@request-claude-review\` to retry."
           fi
+          "$REVIEW_CLI" reply \
+            --repo "$GH_REPO" \
+            --event "$EVENT_NAME" \
+            --edit-reply "$REPLY_ID" \
+            --body "$BODY"
+
+      # Cancellation is a third terminal state, not a kind of failure. It
+      # gets its own step because `cancelled()` is the only documented way to
+      # detect it; the previous version branched on `job.status` inside the
+      # step above, which may never have matched.
+      #
+      # The copy reports the observable fact and hedges the cause. The
+      # earlier wording asserted a supersede, but a manual cancel from the
+      # Actions UI produces the same state with no newer review behind it, so
+      # that stated a cause we cannot know. It also dropped the retry hint,
+      # which matters most on exactly that path, because nothing else is
+      # coming.
+      - name: Update threaded reply when the run is cancelled
+        if: |
+          cancelled() &&
+          needs.triage.outputs.reply_id != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          REPLY_ID: ${{ needs.triage.outputs.reply_id }}
+          EVENT_NAME: ${{ github.event_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REVIEW_CLI: ${{ steps.install.outputs.bin }}
+          BUN_CONFIG_FILE: /dev/null
+        run: |
+          # Cancellation can land before the install step finished, in which
+          # case there is no binary to post with. Exit clean rather than
+          # failing a step whose job is already cancelled.
+          if [ -z "${REVIEW_CLI:-}" ] || [ ! -x "$REVIEW_CLI" ]; then
+            echo "review-cli not installed (cancelled early); leaving the reply as-is"
+            exit 0
+          fi
+          BODY="⏹ **Cancelled** · this run was cancelled before finishing — most often because a newer push to this PR started a fresh review · [view run ↗](${RUN_URL}) · comment \`@request-claude-review\` if you still need one."
           "$REVIEW_CLI" reply \
             --repo "$GH_REPO" \
             --event "$EVENT_NAME" \


### PR DESCRIPTION
Follow-up to #123. Every item here came from review-cli reviewing the equivalent change to its own consumer workflow in [Uniswap/tjar#10](https://github.com/Uniswap/tjar/pull/10) (now merged as `7fae6c8`), which found three things #123 shipped with. Item 5 corrects a mistake I made while fixing the others.

Squashed into a single signed commit (`22d86a9`, `verified=true`). The earlier four commits were created through the GitHub Git Data API rather than `git commit`, so they carried no signature; this one is SSH-signed locally.

## 1. The cancelled branch may never have run

#123 selected the cancelled state in bash:

```bash
elif [ "$OUTCOME" = "cancelled" ]; then   # OUTCOME = ${{ job.status }}
```

`job.status` is documented to be one of `success` / `failure` / `cancelled`, but nothing specifies that it interpolates to `cancelled` for a step belonging to the job that is *currently being cancelled*. I did not verify that it does, so the branch may have been dead code.

Rather than test the assumption, the dependency is gone. Cancellation now has its own step gated on `cancelled()`, the documented status-check function. The success/failure step is gated `!cancelled()` and keeps the `job.status` compare only to choose between those two, which is the path already exercised on real runs. The two gates are mutually exclusive, so the reply is written exactly once on every terminal state.

## 2. The copy asserted a cause it cannot know

Before:

> ⏹ **Superseded** · a newer push to this PR started a fresh review, so this one was cancelled

A manual cancel from the Actions UI produces the identical state with no newer review behind it, so this asserted something we cannot know. It also dropped the retry hint the failure branch carries, on exactly the path where nothing else is coming. Now:

> ⏹ **Cancelled** · this run was cancelled before finishing, most often because a newer push to this PR started a fresh review · [view run ↗] · comment `@request-claude-review` if you still need one.

## 3. Cancelling reviews that nothing replaces

`cancel-in-progress` fired on every `pull_request` event, including pushes the triage gate then refuses: a human's draft, or a fork PR. Those cancelled a comment-triggered review while their own triage skipped, leaving the requester with a reply stuck on "Review running" and nothing coming.

The predicate now mirrors the first clause of the triage gate:

```
${{ github.event_name == 'pull_request'
    && github.event.pull_request.head.repo.fork == false
    && (github.event.pull_request.draft == false
        || github.event.action == 'ready_for_review'
        || github.event.pull_request.user.login == 'claude[bot]') }}
```

Deliberately **not** a bare `draft == false`. This repo does review `claude[bot]` drafts (`.claude/review.yml` sets `skip.drafts: false`), so a push to one should still supersede the in-flight run. The predicate tracks the gate, not a generic draft rule.

Folded scalar with continuation lines at matching indent, so YAML collapses it to a single line (243 chars, no embedded newline) before Actions parses it.

## 4. Documentation, which the docs-check gate correctly demanded

`docs-check` failed this PR on the first push, and it was right: cancellation behavior changed materially and `.github/workflows/CLAUDE.md` still described only success and failure. Added a Cancellation section covering what causes a cancellation, why one concurrency group spans every trigger type, the predicate above and why it is not a bare `draft == false` here, the three terminal states with their gates and user-visible signals, and what a commenter should do when their request is cancelled.

It also records two known rough edges on the manual-cancel path:

- The sticky summary still strands `post --pre`'s "Review running" placeholder. There is no workflow-level fix: `post` accepts exactly four options on `origin/main` and in the published 1.10.3 (`repo`, `dryRun`, `yes`, `pre`), none of which writes a terminal sticky, and the sticky's comment id is not a step output. Filed as [Uniswap/internal-tools#155](https://github.com/Uniswap/internal-tools/issues/155).
- A run cancelled while still **queued** allocates no job, so no finalization step runs at all, `cancelled()` included. Harmless, because `triage` never ran either, so there is no 👀 or reply left stale. Both cancelled runs on the tjar branch were this kind.

## 5. The reaction emoji, which I got wrong first

My first version of the terminal-state table named the wrong reactions. `outcomeToReaction` (`packages/review-cli/src/reactions.ts`) maps `ack` → `eyes`, `success` → `'+1'`, `failure` → `'-1'`, which render 👀 / 👍 / 👎. The ✅ and ❌ in the *threaded reply bodies* are correct, since those are markdown we author; only the reaction on the trigger comment was misdescribed. Corrected in the table, in the same claim in a workflow comment, and in a step name that advertised "(✅ / ❌)" and was what misled me in the first place. Step names are display-only, so nothing depends on the rename.

Worth noting that `docs-check` went green while that table was still wrong. The gate checks that cancellation *is* documented, not that the documentation is accurate.

## Also

The new cancelled step exits clean when `$REVIEW_CLI` is not executable, since cancellation can land before the install step finished and there is no binary to post with on that path.

## Test plan

- [x] `actionlint -shellcheck=""` clean
- [x] `zizmor --persona regular` reports no findings
- [x] `prettier@2.8.8 --check` with the repo's `.prettierrc.json` (what `nx format:check` runs) passes on both changed files
- [x] `markdownlint-cli2@0.14.0` with the repo's `.markdownlint-cli2.jsonc`: 0 errors
- [x] YAML parses; `cancel-in-progress` verified to fold to one line
- [x] The three `if:` gates verified as `!cancelled()`, `!cancelled()`, `cancelled()`
- [x] Asserted absent: the bash `"$OUTCOME" = "cancelled"` compare, the `job.status != 'cancelled'` gate, and the old `⏹ **Superseded**` copy
- [x] Reaction mapping read from `reactions.ts` rather than inferred from the flag's description string

Not covered: no real cancellation has exercised the new step. The change relies on a documented mechanism rather than a tested one, which is the whole reason the `job.status` dependency was removed instead of verified.
