### PR TITLE
docs(ci): correct two unverified claims about the review skip overrides

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -77,12 +77,23 @@ deliberately **not** vendored here.
 **Automated PRs** are classified by the shared
 `.github/actions/check-automated-pr` composite action — the same one
 `ci-pr-checks.yml` and `ci-check-pr-title.yml` use, so there is one
-definition. Automated PRs are skipped except `deps`, which are reviewed so
-`auto-merge-dependabot` has a review result to gate on. Consequently
+definition. Automated PRs are skipped except `deps`.
+
 `.claude/review.yml` sets `skip.branch_prefixes: []`, `skip.authors: []`,
-and `skip.drafts: false`: the CLI's own defaults would otherwise skip
-every bot-authored PR (including `claude[bot]`, which opens most PRs here)
-and every Dependabot PR, silently disabling auto-merge.
+and `skip.drafts: false` because the CLI's own defaults
+(`authors: ['*[bot]']`, `drafts: true`, and the `dependabot/` / `renovate/`
+branch prefixes) would otherwise drop any bot-authored or draft PR outright.
+This repo does get `claude[bot]` PRs and does want its drafts reviewed, so
+those defaults are wrong here — though bot-authored PRs are a minority
+(2 of the last 30 as of 2026-08-03; most are human-authored).
+
+**`auto-merge-dependabot` is currently inert.** There is no
+`.github/dependabot.yml`, `automated-security-fixes` reports
+`enabled: false`, and the repo has never received a Dependabot PR. Before
+trusting that job, note it gates on `needs.review.result == 'success'`,
+which means the review job did not crash — not that the review approved. A
+`REQUEST_CHANGES` verdict still leaves the job result `success`. Fix that
+gate before enabling Dependabot.
 
 **Triggering a new review:**
 


### PR DESCRIPTION
Documentation only. No behavior change.

While auditing the review workflow I checked two claims I had written in #123 to justify the `skip` overrides. Both were asserted rather than verified, and both are wrong.

## What was wrong

**"`claude[bot]`, which opens most PRs here"**

It is 2 of the last 30. Twenty are `wkoutre`, six `dgilmanuni`. I had seen two open PRs, both Claude-authored, and generalized that to "most."

**"`deps` PRs are reviewed so `auto-merge-dependabot` has a review result to gate on"**

That path does not exist:

- no `.github/dependabot.yml`
- `GET /repos/Uniswap/uniswap-ai/automated-security-fixes` returns `{"enabled": false, "paused": false}`
- the repo has never received a Dependabot PR

So the sentence describes a dependency that was never there, and "silently disabling auto-merge" was a consequence that could not occur.

## What is still true

The overrides are correct and unchanged. `DEFAULT_CONFIG.skip` in the CLI is `authors: ['*[bot]']`, `drafts: true`, plus `dependabot/` and `renovate/` branch prefixes, so inheriting it would drop every bot-authored and every draft PR. This repo does get `claude[bot]` PRs and does want its drafts reviewed. Only my reasoning was wrong, not the config.

## What this adds

A note that `auto-merge-dependabot` is inert today, and that its gate is wrong in a way worth knowing before anyone enables Dependabot:

```yaml
needs.review.result == 'success'
```

That tests whether the review **job** crashed, not whether the review **approved**. A `REQUEST_CHANGES` verdict still leaves the job result `success`, so as written the gate would auto-merge a PR the reviewer objected to.

## Test plan

- [x] `prettier@2.8.8 --check` with the repo's `.prettierrc.json` (what `nx format:check` runs) passes
- [x] `markdownlint-cli2@0.14.0` with the repo's `.markdownlint-cli2.jsonc`: 0 errors
- [x] Asserted both wrong phrases are gone from the file
- [x] Every replacement number re-derived from the API, not from memory

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Documentation only. No behavior change.
Two claims in `.github/workflows/CLAUDE.md` (added in #123 to justify the `skip` overrides) were asserted rather than verified. Both are wrong.
## What was wrong
**"`claude[bot]`, which opens most PRs here"** — actually 2 of the last 30. The rest are human-authored (`wkoutre`, `dgilmanuni`).
**"`deps` PRs are reviewed so `auto-merge-dependabot` has a review result to gate on"** — that path does not exist:
- no `.github/dependabot.yml`
- `GET /repos/Uniswap/uniswap-ai/automated-security-fixes` returns `{"enabled": false, "paused": false}`
- the repo has never received a Dependabot PR
## What is still true
The overrides themselves are correct and unchanged. `DEFAULT_CONFIG.skip` in the CLI is `authors: ['*[bot]']`, `drafts: true`, plus `dependabot/` and `renovate/` branch prefixes — inheriting it would drop every bot-authored and every draft PR. This repo does get `claude[bot]` PRs and does want its drafts reviewed. Only the reasoning was wrong.
## What this adds
A note that `auto-merge-dependabot` is inert today, and that its gate is wrong in a way worth knowing before anyone enables Dependabot:
```yaml
needs.review.result == 'success'
```
That tests whether the review **job** crashed, not whether the review **approved**. A `REQUEST_CHANGES` verdict still leaves the job result `success`, so as written the gate would auto-merge a PR the reviewer objected to.
## Test plan
- [x] `prettier@2.8.8 --check` with the repo's `.prettierrc.json` (what `nx format:check` runs) passes
- [x] `markdownlint-cli2@0.14.0` with the repo's `.markdownlint-cli2.jsonc`: 0 errors
- [x] Asserted both wrong phrases are gone from the file
- [x] Every replacement number re-derived from the API, not from memory

</details>
<!-- claude-pr-description-end -->