### PR TITLE
chore(ci): remove the inert auto-merge-dependabot job

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -87,13 +87,24 @@ This repo does get `claude[bot]` PRs and does want its drafts reviewed, so
 those defaults are wrong here — though bot-authored PRs are a minority
 (2 of the last 30 as of 2026-08-03; most are human-authored).
 
-**`auto-merge-dependabot` is currently inert.** There is no
-`.github/dependabot.yml`, `automated-security-fixes` reports
-`enabled: false`, and the repo has never received a Dependabot PR. Before
-trusting that job, note it gates on `needs.review.result == 'success'`,
-which means the review job did not crash — not that the review approved. A
-`REQUEST_CHANGES` verdict still leaves the job result `success`. Fix that
-gate before enabling Dependabot.
+**There is no Dependabot auto-merge.** An `auto-merge-dependabot` job used
+to live in `claude-code-review.yml` and was removed, because it could not
+run and its gate was wrong. If you ever want it back, two things have to be
+true that were not:
+
+- **Dependabot has to actually produce PRs here.** This repo has only
+  `bun.lock`, and Dependabot's `bun` ecosystem supports version updates but
+  **not** security updates. Enabling `automated-security-fixes` gains
+  nothing for these dependencies; version updates need a
+  `.github/dependabot.yml` with `package-ecosystem: bun`.
+- **The gate has to test the verdict, not the exit code.** The removed job
+  gated on `needs.review.result == 'success'`, which means the review job
+  did not crash — not that the review approved. A `REQUEST_CHANGES` verdict
+  still leaves the job result `success`, so as written it would have
+  auto-merged a PR the reviewer objected to.
+
+Dependabot alerts are already enabled, so vulnerable dependencies surface
+today; they just get bumped by hand.
 
 **Triggering a new review:**
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -8,10 +8,10 @@
 # preserve this repo's extra behavior: automated-PR classification,
 # the skipped-review notice, and Dependabot auto-merge.
 #
-# Four triggers, four jobs:
+# Four triggers, three jobs:
 #
 #   pull_request                ┐
-#   issue_comment               ├──▶ triage (gate) ──▶ review ──▶ auto-merge-dependabot
+#   issue_comment               ├──▶ triage (gate) ──▶ review
 #   pull_request_review_comment │                  └──▶ review-skipped
 #   workflow_dispatch           ┘
 #
@@ -365,11 +365,12 @@ jobs:
   review:
     name: AI review
     needs: triage
-    # Automated PRs are skipped EXCEPT dependency bumps, which are
-    # reviewed so auto-merge-dependabot below has a review result to gate
-    # on. Identical to the outgoing workflow's condition. `is_automated`
-    # is empty for comment and manual triggers (the classifier step is
-    # skipped), so those always proceed.
+    # Automated PRs are skipped EXCEPT dependency bumps. Those are worth
+    # reviewing on their own merits (supply-chain risk, breaking changes in
+    # a transitive major), and `.claude/review.yml` staffs
+    # dependency-upgrade-reviewer for them. `is_automated` is empty for
+    # comment and manual triggers (the classifier step is skipped), so
+    # those always proceed.
     if: |
       needs.triage.outputs.run == 'true' &&
       (needs.triage.outputs.is_automated != 'true' || needs.triage.outputs.category == 'deps')
@@ -751,29 +752,3 @@ jobs:
         run: |
           echo "::notice::Code review skipped for automated PR: $SKIP_REASON"
           echo "✅ Automated PR detected - code review is not required for this PR type."
-
-  # Auto-merge Dependabot security updates once the review passes.
-  # Preserved from the outgoing workflow, including the title filter.
-  # This is why `deps` PRs are exempted from the automated-PR skip above:
-  # without a review result to gate on, this job would never fire.
-  auto-merge-dependabot:
-    name: Auto-merge Dependabot
-    needs: review
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.pull_request.user.login == 'dependabot[bot]' &&
-      (contains(github.event.pull_request.title, 'security') || contains(github.event.pull_request.title, 'Bump')) &&
-      needs.review.result == 'success'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # `gh pr merge --auto` queues a merge commit
-      pull-requests: write # sets the auto-merge flag on the PR
-    steps:
-      - uses: bullfrogsec/bullfrog@1831f79cce8ad602eef14d2163873f27081ebfb3 # v0.8.4
-
-      - name: Enable auto-merge for Dependabot updates
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-        run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,8 +5,8 @@
 # template (packages/review-cli/templates/workflows/review.yml in
 # Uniswap/internal-tools) and the shape already running in
 # Uniswap/backend, Uniswap/universe, and Uniswap/tjar, then adapted to
-# preserve this repo's extra behavior: automated-PR classification,
-# the skipped-review notice, and Dependabot auto-merge.
+# preserve this repo's extra behavior: automated-PR classification and
+# the skipped-review notice.
 #
 # Four triggers, three jobs:
 #


### PR DESCRIPTION
Removes the `auto-merge-dependabot` job. It could not run, and its gate was wrong, so fixing it would have meant repairing machinery nothing uses.

## It could not run

- no `.github/dependabot.yml`
- `GET /repos/Uniswap/uniswap-ai/automated-security-fixes` returns `{"enabled": false, "paused": false}`
- the repo has never received a Dependabot PR

And flipping that switch would not have helped. This repo has only `bun.lock`, and per [GitHub's supported-ecosystems table](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories) Dependabot's `bun` ecosystem supports **version updates but not security updates**. So `automated-security-fixes` gains nothing for these dependencies, which is exactly what the job was for.

## Its gate was wrong

```yaml
needs.review.result == 'success'
```

That tests whether the review **job** crashed, not whether the review **approved**. A `REQUEST_CHANGES` verdict still leaves the job result `success`, so the job would have auto-merged a PR the reviewer objected to.

The two problems compound rather than cancel. Version-update PRs are titled `Bump X from Y to Z`, which matches this job's own `contains(title, 'Bump')` filter, so adding a `dependabot.yml` later would have made the job live and wrong in the same moment. Deleting it now means whoever enables Dependabot builds the gate deliberately instead of inheriting a broken one.

## What changed

All four references, so nothing documents or diagrams a job that no longer exists:

1. The job itself.
2. The trigger diagram in the header ("four jobs" is now three).
3. The `deps`-exemption comment on the `review` job, which cited this job as its reason.
4. The `.github/workflows/CLAUDE.md` paragraph, replaced with what a future enabler actually needs: the bun-ecosystem limitation and the gate bug.

**The `deps` exemption itself is unchanged.** Dependency bumps are still reviewed, now for a reason that survives: supply-chain risk and breaking transitive majors, with `dependency-upgrade-reviewer` already staffed for them in `.claude/review.yml`. Only the stated justification moved.

Dependabot alerts remain enabled (`vulnerability-alerts` returns 204), so vulnerable dependencies still surface; they get bumped by hand, which was already the real workflow.

## Test plan

- [x] `actionlint -shellcheck=""` clean
- [x] `zizmor --persona regular` reports no findings
- [x] `prettier@2.8.8 --check` with the repo's `.prettierrc.json` (what `nx format:check` runs) passes on both files
- [x] `markdownlint-cli2@0.14.0` with the repo's `.markdownlint-cli2.jsonc`: 0 errors
- [x] Remaining jobs parse as exactly `triage`, `review`, `review-skipped`
- [x] Asserted absent from the workflow: the job key, the job name, `gh pr merge --auto`, and any remaining `auto-merge-dependabot` reference
- [x] Confirmed no other workflow in the repo references the job
- [x] Confirmed it is not a required status check on `main`

<!-- claude-pr-description-start -->
<details>
<summary>AI-Generated Description</summary>

Removes the `auto-merge-dependabot` job. It could not run, and its gate was wrong, so fixing it would have meant repairing machinery nothing uses.
## It could not run
- no `.github/dependabot.yml`
- `GET /repos/Uniswap/uniswap-ai/automated-security-fixes` returns `{"enabled": false, "paused": false}`
- the repo has never received a Dependabot PR
And flipping that switch would not have helped. This repo has only `bun.lock`, and per [GitHub's supported-ecosystems table](https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories) Dependabot's `bun` ecosystem supports **version updates but not security updates**. So `automated-security-fixes` gains nothing for these dependencies, which is exactly what the job was for.
## Its gate was wrong
```yaml
needs.review.result == 'success'
```
That tests whether the review **job** crashed, not whether the review **approved**. A `REQUEST_CHANGES` verdict still leaves the job result `success`, so the job would have auto-merged a PR the reviewer objected to.
The two problems compound rather than cancel. Version-update PRs are titled `Bump X from Y to Z`, which matches this job's own `contains(title, 'Bump')` filter, so adding a `dependabot.yml` later would have made the job live and wrong in the same moment. Deleting it now means whoever enables Dependabot builds the gate deliberately instead of inheriting a broken one.
## What changed
All four references, so nothing documents or diagrams a job that no longer exists:
1. The job itself.
2. The trigger diagram in the header ("four jobs" is now three).
3. The `deps`-exemption comment on the `review` job, which cited this job as its reason.
4. The `.github/workflows/CLAUDE.md` paragraph, replaced with what a future enabler actually needs: the bun-ecosystem limitation and the gate bug.
**The `deps` exemption itself is unchanged.** Dependency bumps are still reviewed, now for a reason that survives: supply-chain risk and breaking transitive majors, with `dependency-upgrade-reviewer` already staffed for them in `.claude/review.yml`. Only the stated justification moved.
Dependabot alerts remain enabled (`vulnerability-alerts` returns 204), so vulnerable dependencies still surface; they get bumped by hand, which was already the real workflow.
## Test plan
- [x] `actionlint -shellcheck=""` clean
- [x] `zizmor --persona regular` reports no findings
- [x] `prettier@2.8.8 --check` with the repo's `.prettierrc.json` (what `nx format:check` runs) passes on both files
- [x] `markdownlint-cli2@0.14.0` with the repo's `.markdownlint-cli2.jsonc`: 0 errors
- [x] Remaining jobs parse as exactly `triage`, `review`, `review-skipped`
- [x] Asserted absent from the workflow: the job key, the job name, `gh pr merge --auto`, and any remaining `auto-merge-dependabot` reference
- [x] Confirmed no other workflow in the repo references the job
- [x] Confirmed it is not a required status check on `main`

</details>
<!-- claude-pr-description-end -->