### PR TITLE
chore(deps): maintain Claude Code Action workflows (v1.0.185)

### DIFF
--- a/.github/workflows/claude-docs-check.yml
+++ b/.github/workflows/claude-docs-check.yml
@@ -54,13 +54,13 @@ jobs:
       (github.event_name == 'pull_request' &&
        !contains(github.event.pull_request.user.login, '[bot]') &&
        github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@6d35d60ab7805aefae2837776d870787d93c8a18 # main
+    uses: Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml@c4820d6e62a9488c831e722aac202733fafab5dd # main
     with:
       pr_number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
       suggestion_mode: ${{ github.event.inputs.suggestion_mode || 'suggest' }}
       auto_commit: ${{ github.event.inputs.auto_commit == 'true' }}
       # Use sonnet for faster, cheaper checks
-      model: 'claude-sonnet-4-5-20250929'
+      model: 'claude-sonnet-5'
       # Fail if plugin versions aren't bumped
       fail_on_missing_version: true
       # Fail if documentation is not updated

--- a/.github/workflows/generate-pr-title-description.yml
+++ b/.github/workflows/generate-pr-title-description.yml
@@ -47,12 +47,12 @@ jobs:
       !contains(github.head_ref, 'release/') &&
       !startsWith(github.event.pull_request.title, 'chore(release):')
 
-    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@6d35d60ab7805aefae2837776d870787d93c8a18
+    uses: Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml@c4820d6e62a9488c831e722aac202733fafab5dd
     with:
       generation_mode: 'title,description'
       pr_number: ${{ github.event.pull_request.number }}
       base_ref: ${{ github.base_ref }}
-      # Use default model (claude-sonnet-4-5-20250929)
+      # Use default model (claude-sonnet-5)
       # Use default timeout (15 minutes)
       # Use default prompt from ai-toolkit
       commit_history_count: 30


### PR DESCRIPTION
## Summary

Maintenance pass on Claude Code Action workflows. Applies three classes of edit atomically:

- **claude-code-action:** `v1.0.185` (`9db594c`) — see https://github.com/anthropics/claude-code-action/releases/tag/v1.0.185
- **ai-toolkit reusable workflows:** `c4820d6` (Uniswap/ai-toolkit `main` HEAD, the released branch)
- **Models:**
  - `haiku` → `claude-haiku-4-5-20251001`
  - `opus` → `claude-opus-5`
  - `sonnet` → `claude-sonnet-5`

### Per-file changes

#### `.github/workflows/claude-docs-check.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_claude-docs-check.yml`: `6d35d60` → `c4820d6`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-5`

#### `.github/workflows/generate-pr-title-description.yml`
- SHA bump `Uniswap/ai-toolkit/.github/workflows/_generate-pr-metadata.yml`: `6d35d60` → `c4820d6`
- Model bump: `claude-sonnet-4-5-20250929` → `claude-sonnet-5`

---

_Opened by the `sync-claude-code-action` maintenance job. The job runs weekly and bumps SHAs + applies known migrations; review the diff before merging._