### PR TITLE
fix(scripts): enforce plugin.json and package.json version parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,15 @@ All plugins follow semantic versioning (semver):
 
 After making any changes to `packages/plugins/`, bump the plugin version in `.claude-plugin/plugin.json`.
 
+`.claude-plugin/plugin.json` is the authoritative version for a plugin. It is what
+Claude Code reads, what `.claude-plugin/marketplace.json` resolves, and what the
+skill validation in CI checks against. Each plugin's `package.json` also carries a
+`version` field, and it must be kept equal to the `plugin.json` value.
+
+Bump `plugin.json` first, then set `package.json` to the same value.
+`scripts/validate-plugin.cjs` fails when the two disagree, and CI runs it on every
+plugin, so a mismatch blocks the PR.
+
 ## Agent-Agnostic Design
 
 All AI tools in this repo should be usable by ANY LLM coding agent, not just Claude Code:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,8 @@ All plugins follow semantic versioning (semver):
 After making any changes to `packages/plugins/`, bump the plugin version in `.claude-plugin/plugin.json`.
 
 `.claude-plugin/plugin.json` is the authoritative version for a plugin. It is what
-Claude Code reads, what `.claude-plugin/marketplace.json` resolves, and what the
-skill validation in CI checks against. Each plugin's `package.json` also carries a
-`version` field, and it must be kept equal to the `plugin.json` value.
+Claude Code reads. Each plugin's `package.json` also carries a `version` field, and
+it must be kept equal to the `plugin.json` value.
 
 Bump `plugin.json` first, then set `package.json` to the same value.
 `scripts/validate-plugin.cjs` fails when the two disagree, and CI runs it on every

--- a/packages/plugins/uniswap-cca/package.json
+++ b/packages/plugins/uniswap-cca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswap-cca",
-  "version": "1.2.5",
+  "version": "1.2.7",
   "private": true,
   "description": "Configure and deploy Continuous Clearing Auction (CCA) smart contracts",
   "files": [

--- a/packages/plugins/uniswap-driver/package.json
+++ b/packages/plugins/uniswap-driver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswap-driver",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "private": true,
   "description": "AI-powered assistance for planning Uniswap swaps and liquidity positions",
   "author": {

--- a/packages/plugins/uniswap-trading/package.json
+++ b/packages/plugins/uniswap-trading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswap-trading",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "private": true,
   "description": "Integrate Uniswap swaps via Trading API, Universal Router SDK, or direct smart contract calls",
   "author": "Uniswap Labs <ai-services@uniswap.org>",

--- a/packages/plugins/uniswap-viem/package.json
+++ b/packages/plugins/uniswap-viem/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswap-viem",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": true,
   "description": "EVM blockchain integration using viem and wagmi - client setup, reading/writing data, accounts, contract interactions, and React hooks",
   "author": "Uniswap Labs <ai-services@uniswap.org>",

--- a/scripts/validate-plugin.cjs
+++ b/scripts/validate-plugin.cjs
@@ -31,6 +31,13 @@
  *   - project.json has 'type:plugin' tag
  *   - Referenced component directories exist
  *   - JSON files are valid
+ *   - plugin.json and package.json declare the same version
+ *
+ * Version parity:
+ *   .claude-plugin/plugin.json is the authoritative version for a plugin. It is
+ *   what Claude Code reads, what the marketplace resolves, and what CLAUDE.md
+ *   tells contributors to bump. package.json must be kept equal to it so the two
+ *   never disagree about which release a plugin is on.
  */
 
 const fs = require('fs');
@@ -83,6 +90,8 @@ function checkEvalCoverage(pluginPath) {
 function validatePlugin(pluginPath) {
   const errors = [];
   const warnings = [];
+  let pluginVersion;
+  let packageVersion;
 
   console.log(`\nValidating plugin: ${pluginPath}\n`);
 
@@ -123,6 +132,8 @@ function validatePlugin(pluginPath) {
         }
       }
 
+      pluginVersion = pluginJson.version;
+
       console.log(`  ✓ plugin.json: ${pluginJson.name} v${pluginJson.version}`);
     } catch {
       errors.push(`Invalid JSON in plugin.json`);
@@ -142,9 +153,23 @@ function validatePlugin(pluginPath) {
         errors.push(`package.json missing version field`);
       }
 
-      console.log(`  ✓ package.json: ${packageJson.name}`);
+      packageVersion = packageJson.version;
+
+      console.log(`  ✓ package.json: ${packageJson.name} v${packageJson.version}`);
     } catch {
       errors.push(`Invalid JSON in package.json`);
+    }
+  }
+
+  // Version parity: plugin.json is authoritative, package.json must match it.
+  if (pluginVersion && packageVersion) {
+    if (pluginVersion === packageVersion) {
+      console.log(`  ✓ version parity: ${pluginVersion}`);
+    } else {
+      errors.push(
+        `Version mismatch: .claude-plugin/plugin.json is ${pluginVersion} but package.json is ${packageVersion}. ` +
+          `plugin.json is authoritative, so set package.json "version" to ${pluginVersion}.`
+      );
     }
   }
 

--- a/scripts/validate-plugin.cjs
+++ b/scripts/validate-plugin.cjs
@@ -35,9 +35,9 @@
  *
  * Version parity:
  *   .claude-plugin/plugin.json is the authoritative version for a plugin. It is
- *   what Claude Code reads, what the marketplace resolves, and what CLAUDE.md
- *   tells contributors to bump. package.json must be kept equal to it so the two
- *   never disagree about which release a plugin is on.
+ *   what Claude Code reads and what CLAUDE.md tells contributors to bump.
+ *   package.json must be kept equal to it so the two never disagree about which
+ *   release a plugin is on.
  */
 
 const fs = require('fs');


### PR DESCRIPTION
## Problem

Every plugin under `packages/plugins/` declares a version in two places:
`.claude-plugin/plugin.json` and `package.json`. The versioning rule in the root
`CLAUDE.md` names only `plugin.json`, and nothing in CI compares the two, so
`package.json` silently falls behind.

Verified on `main` at `bd5f306`, 4 of 7 plugins had drifted, and every one of them
had `package.json` behind `plugin.json`, never ahead:

| Plugin | plugin.json | package.json |
| --- | --- | --- |
| uniswap-cca | 1.2.7 | 1.2.5 |
| uniswap-driver | 0.5.4 | 0.5.3 |
| uniswap-trading | 1.10.1 | 1.10.0 |
| uniswap-viem | 1.1.6 | 1.1.5 |
| uniswap-hooks | 1.6.0 | 1.6.0 |
| uniswap-permissioned-pools | 0.3.2 | 0.3.2 |
| uniswap-trading-tools | 0.2.0 | 0.2.0 |

## What this changes

**`plugin.json` is authoritative.** It is what Claude Code reads and what the
`Plugin Versioning` rule in `CLAUDE.md` tells contributors to bump. The drift
direction confirms it in practice: bumps land in `plugin.json`, and `package.json`
is the copy that gets forgotten.

For the record, two things that might sound like corroboration are not, and an
earlier revision of this description wrongly claimed them. `marketplace.json`
plugin entries carry only `name`, `source`, and `description`, so the marketplace
resolves a source path and never a version. `.github/actions/validate-skills`
contains no reference to a version at all; it checks skill declarations. Neither
file has an opinion about which version field wins.

1. **`scripts/validate-plugin.cjs` now fails when the two versions disagree.**
   It already parsed both files, so the check reuses that parse. The failure names
   both values and the corrective action:

   ```
   ✗ Version mismatch: .claude-plugin/plugin.json is 1.2.7 but package.json is 1.2.5.
     plugin.json is authoritative, so set package.json "version" to 1.2.7.
   Validation FAILED with 1 error(s)
   ```

   It is an error, not a warning, so it exits non-zero. `.github/actions/validate-plugins`
   runs this script on every plugin listed in `marketplace.json`, and all 7 on disk are
   listed, so the `Validate Plugins` CI job covers every plugin with no workflow change.
   On a matching pair it prints `✓ version parity: <version>`.

2. **The 4 drifted `package.json` files are synced up** to their `plugin.json` value.

3. **The `Plugin Versioning` section of `CLAUDE.md` now states the rule**, so the
   convention is written down rather than only enforced.

## Publishing impact: none

The prior concern was that touching `package.json` versions could affect npm
publishing. It cannot here, on four independent pieces of evidence:

- All 7 plugin `package.json` files are `"private": true`, and none sets `publishConfig`.
- `nx.json` `release.projects` is `[]`, so no project is release configured.
- `.github/workflows/publish-packages.yml` filters on both of those. Auto mode logs
  `⏭️ Skipping $project (private: true)`, and force mode requires membership in
  `nx.json` `release.projects` or it errors out.
- `https://registry.npmjs.org/@uniswap/uniswap-{cca,driver,trading,viem}` all return
  404. These packages have never been published.

`nx release version` writes to `package.json`, so if a plugin were ever made public
the drift would matter. That is the argument for the check, not against the sync.

I chose the conservative sync direction: raise `package.json` to the existing
`plugin.json` value rather than bump both to a new number. No version is invented,
and the correct value is the one already recorded in `plugin.json`.

## Verification

Run locally on this branch:

- `bunx nx format:check --base=origin/main --head=HEAD` passes
- `bunx markdownlint-cli2 "CLAUDE.md"` 0 errors
- `node scripts/validate-plugin.cjs <plugin>` PASSED for all 7 plugins
- `bun run scripts/check-eval-coverage.ts` 18 skills covered
- New check proven to fail before the sync on exactly the 4 drifted plugins, and to
  pass on the 3 that were already aligned

`bun install --frozen-lockfile` still passes without a `bun.lock` change. Bun does not
copy a workspace package's `version` field into the lockfile on install, so the lock
keeps its previous values and CI is unaffected.
