### PR TITLE
test(cca): grade the supply total deterministically in configurator evals

### DIFF
--- a/docs/plugins/uniswap-cca.md
+++ b/docs/plugins/uniswap-cca.md
@@ -63,7 +63,7 @@ CCA uses Q96 fixed-point arithmetic for precise pricing:
 
 ### MPS (Milli-Basis Points)
 
-Supply schedules use MPS = 1e7 (10 million). Each MPS unit represents one thousandth of a basis point. Schedule steps are defined as `{mps, blockDelta}` pairs that always total exactly 10,000,000 MPS.
+Supply schedules use MPS = 1e7 (10 million). Each MPS unit represents one thousandth of a basis point. Schedule steps are defined as `{mps, blockDelta}` pairs, and the released supply always totals exactly 10,000,000 MPS, computed as `sum(mps * blockDelta)`. `mps` is a per-block release rate, not a per-step amount, so the `mps` values alone do not sum to 10,000,000.
 
 ### Factory Deployment
 

--- a/evals/suites/configurator/assertions/supply-schedule-total.js
+++ b/evals/suites/configurator/assertions/supply-schedule-total.js
@@ -11,11 +11,17 @@
  * the gate flips on chance and "just re-run it" becomes the reflex.
  *
  * THE TOTAL IS NOT THE SUM OF THE `mps` FIELDS. `mps` is a release rate, tokens
- * per block, and `blockDelta` is how many blocks that rate runs for. The total is
- * therefore the sum of `mps * blockDelta` over the steps. The skill's own worked
- * example (SKILL.md, "Example: 2-day auction on Base") has `mps` fields summing to
- * 2,989,006 while `mps * blockDelta` sums to exactly 10,000,000. A check on the
- * bare `mps` column would fail every correct answer.
+ * per block, and `blockDelta` is how many blocks that rate runs for. The formula
+ * here is the plugin's own, copied from the generator that produces these
+ * schedules, `mcp-server/supply-schedule/server.py`:
+ *
+ *     total_mps = sum(item["mps"] * item["blockDelta"] for item in schedule)
+ *
+ * The skill's worked example agrees: its `mps` fields sum to 2,989,006 while the
+ * products sum to exactly 10,000,000. A check on the bare `mps` column would fail
+ * every correct answer, and a response built on that reading oversubscribes the
+ * auction by a factor of thousands while looking tidy, which is a failure both
+ * rubrics scored 1.0 on before this assertion existed.
  *
  * THE SUITE'S STANDING RULE: an assertion may only fail a WRONG answer. Two prior
  * checks in this suite broke that rule by matching on wording (`AuctionParameters`,

--- a/evals/suites/configurator/assertions/supply-schedule-total.js
+++ b/evals/suites/configurator/assertions/supply-schedule-total.js
@@ -2,8 +2,9 @@
  * Deterministic check on the one property of a CCA supply schedule that is pure
  * arithmetic: its released supply must total exactly 10,000,000 MPS.
  *
- * WHY THIS IS NOT A RUBRIC. The correctness rubric grades this today, and an LLM
- * judge grading exact arithmetic makes a required status check nondeterministic.
+ * WHY THIS IS NOT A RUBRIC. Both rubrics graded this before this file existed, and
+ * an LLM judge grading exact arithmetic makes a required status check
+ * nondeterministic.
  * Two runs of identical content on PR #140 disagreed: run 31846203576 scored the
  * case 1.0, and run 31848655116 failed it because the model's own schedule summed
  * to 9,999,996 MPS, four short. The judge was right that time. The problem is that

--- a/evals/suites/configurator/assertions/supply-schedule-total.js
+++ b/evals/suites/configurator/assertions/supply-schedule-total.js
@@ -1,0 +1,166 @@
+/**
+ * Deterministic check on the one property of a CCA supply schedule that is pure
+ * arithmetic: its released supply must total exactly 10,000,000 MPS.
+ *
+ * WHY THIS IS NOT A RUBRIC. The correctness rubric grades this today, and an LLM
+ * judge grading exact arithmetic makes a required status check nondeterministic.
+ * Two runs of identical content on PR #140 disagreed: run 31846203576 scored the
+ * case 1.0, and run 31848655116 failed it because the model's own schedule summed
+ * to 9,999,996 MPS, four short. The judge was right that time. The problem is that
+ * a property with one correct answer was being decided by a sampled judgment, so
+ * the gate flips on chance and "just re-run it" becomes the reflex.
+ *
+ * THE TOTAL IS NOT THE SUM OF THE `mps` FIELDS. `mps` is a release rate, tokens
+ * per block, and `blockDelta` is how many blocks that rate runs for. The total is
+ * therefore the sum of `mps * blockDelta` over the steps. The skill's own worked
+ * example (SKILL.md, "Example: 2-day auction on Base") has `mps` fields summing to
+ * 2,989,006 while `mps * blockDelta` sums to exactly 10,000,000. A check on the
+ * bare `mps` column would fail every correct answer.
+ *
+ * THE SUITE'S STANDING RULE: an assertion may only fail a WRONG answer. Two prior
+ * checks in this suite broke that rule by matching on wording (`AuctionParameters`,
+ * `educational`), so this one asserts on parsed numbers and is deliberately
+ * conservative in three ways:
+ *
+ *   1. Wording is never matched. Only `{ mps, blockDelta }` pairs are read, in any
+ *      of the shapes a model emits them: JSON, a JS object literal, or a Python
+ *      dict; quoted or bare keys; camelCase or snake_case.
+ *   2. A response with no parseable schedule PASSES. A correct answer that presents
+ *      the schedule as a markdown table, or in prose, must not fail here. The
+ *      `contains-any` check on `supplySchedule` already requires the field to be
+ *      named; this check grades the arithmetic when, and only when, it can read it.
+ *   3. Several totals are considered and ONE of them matching is enough (see
+ *      "candidates" below). Every additional candidate can only turn a fail into a
+ *      pass, never the reverse, so the parser erring on grouping cannot invent a
+ *      failure.
+ *
+ * The failure it does catch is the observed one: a schedule that parses cleanly and
+ * whose arithmetic is wrong.
+ */
+
+const REQUIRED_TOTAL = 10000000n;
+
+// A step, in any of the shapes a model writes one. Chunks are matched without
+// nesting, so a wrapping object such as `"summary": { ... }` is never treated as a
+// step. The lookbehind on the key is what keeps `total_mps` from reading as `mps`,
+// since `\w` covers the underscore.
+const CHUNK = /\{[^{}]*\}/g;
+const MPS_KEY = /(?<!\w)["']?mps["']?\s*[:=]\s*["']?(\d[\d_]*)["']?/i;
+const DELTA_KEY = /(?<!\w)["']?block_?delta["']?\s*[:=]\s*["']?(\d[\d_]*)["']?/i;
+
+// A key that names the emitted schedule, used to tell the response's own
+// configuration apart from an illustrative fragment quoted while explaining.
+const SCHEDULE_KEY = /(?<!\w)["']?(?:supply_?schedule|schedule)["']?\s*[:=]\s*\[?\s*$/i;
+
+/** Steps stay in one group while nothing but whitespace and commas separates them. */
+const GROUP_SEPARATOR = /^[\s,]*$/;
+
+function toInteger(raw) {
+  return BigInt(raw.replace(/_/g, ''));
+}
+
+function parseSteps(output) {
+  const steps = [];
+  for (const match of output.matchAll(CHUNK)) {
+    const mps = MPS_KEY.exec(match[0]);
+    const blockDelta = DELTA_KEY.exec(match[0]);
+    if (!mps || !blockDelta) {
+      continue;
+    }
+    steps.push({
+      mps: toInteger(mps[1]),
+      blockDelta: toInteger(blockDelta[1]),
+      start: match.index,
+      end: match.index + match[0].length,
+    });
+  }
+  return steps;
+}
+
+function groupSteps(output, steps) {
+  const groups = [];
+  let current = null;
+  for (const step of steps) {
+    const separator = current === null ? null : output.slice(current.end, step.start);
+    if (current !== null && GROUP_SEPARATOR.test(separator)) {
+      current.steps.push(step);
+      current.end = step.end;
+      continue;
+    }
+    current = { steps: [step], start: step.start, end: step.end };
+    groups.push(current);
+  }
+  return groups;
+}
+
+function total(steps) {
+  return steps.reduce((sum, step) => sum + step.mps * step.blockDelta, 0n);
+}
+
+/** True when the text immediately before a group names it as the supply schedule. */
+function isNamedSchedule(output, group) {
+  const preceding = output.slice(Math.max(0, group.start - 80), group.start);
+  return SCHEDULE_KEY.test(preceding);
+}
+
+export default function supplyScheduleTotal(output) {
+  const text = typeof output === 'string' ? output : JSON.stringify(output ?? '');
+  const steps = parseSteps(text);
+
+  if (steps.length === 0) {
+    return {
+      pass: true,
+      score: 1,
+      reason:
+        'No { mps, blockDelta } steps could be parsed from the response, so the supply total was not asserted. This check only grades arithmetic it can read; the schedule field itself is required by the contains-any check.',
+    };
+  }
+
+  const groups = groupSteps(text, steps);
+  const named = groups.filter((group) => isNamedSchedule(text, group));
+
+  // Candidates, in the order they are reported. Whole-response and named-only
+  // totals are included so that a schedule split across two code blocks, or
+  // interrupted by a comment line, still has an intact total among the candidates.
+  const candidates = [
+    ...groups.map((group, index) => ({
+      label: `block ${index + 1} (${group.steps.length} step(s))`,
+      value: total(group.steps),
+    })),
+  ];
+  if (named.length > 0) {
+    candidates.push({
+      label: `all steps under a schedule key (${named.reduce(
+        (n, g) => n + g.steps.length,
+        0
+      )} step(s))`,
+      value: total(named.flatMap((group) => group.steps)),
+    });
+  }
+  if (groups.length > 1) {
+    candidates.push({ label: `all ${steps.length} parsed step(s)`, value: total(steps) });
+  }
+
+  const match = candidates.find((candidate) => candidate.value === REQUIRED_TOTAL);
+  if (match) {
+    return {
+      pass: true,
+      score: 1,
+      reason: `Supply schedule totals exactly ${REQUIRED_TOTAL} MPS (sum of mps * blockDelta over ${match.label}).`,
+    };
+  }
+
+  const detail = candidates
+    .map((candidate) => {
+      const delta = candidate.value - REQUIRED_TOTAL;
+      const sign = delta > 0n ? '+' : '';
+      return `${candidate.label}: ${candidate.value} (${sign}${delta})`;
+    })
+    .join('; ');
+
+  return {
+    pass: false,
+    score: 0,
+    reason: `Supply schedule must total exactly ${REQUIRED_TOTAL} MPS, computed as the sum of mps * blockDelta. No parsed schedule does. Totals found: ${detail}.`,
+  };
+}

--- a/evals/suites/configurator/cases/basic-configuration.md
+++ b/evals/suites/configurator/cases/basic-configuration.md
@@ -21,7 +21,8 @@ Configure a Continuous Clearing Auction for a new token launch on Base.
 ## Constraints
 
 - Floor price must be divisible by tick spacing (roundedFloorPrice % tickSpacing == 0)
-- Supply schedule must sum to exactly 10,000,000 MPS
+- Supply schedule must release exactly 10,000,000 MPS in total, computed as
+  `sum(mps * blockDelta)` over all steps (`mps` is a per-block rate, not a per-step amount)
 - Block durations should decrease over time (convex curve property)
 - USDC has 6 decimals on all networks - must divide by 10^12 for 18-decimal tokens
 - Auction duration: 2 days (86,400 blocks on Base)

--- a/evals/suites/configurator/promptfoo.yaml
+++ b/evals/suites/configurator/promptfoo.yaml
@@ -78,6 +78,28 @@ tests:
           - 'supply_schedule'
           - 'supply schedule'
 
+      # Deterministic arithmetic check on the supply total.
+      #
+      # Both rubrics used to grade this property, and an LLM judge deciding exact
+      # arithmetic is what made this required check nondeterministic: two runs of
+      # identical content on PR #140 disagreed, run 31846203576 scoring the case 1.0
+      # and run 31848655116 failing it over a schedule that summed to 9,999,996 MPS.
+      # The judge was right that time; the gate flipping on a sampled judgment is
+      # the problem. This assertion decides the same property by parsing the emitted
+      # steps and summing mps * blockDelta, so it returns the same verdict on the
+      # same response every time. Both rubrics now say explicitly not to score the
+      # total, which is a handoff rather than a relaxation: an off-by-four schedule
+      # that the judge might or might not catch is now caught every time, and caught
+      # exactly.
+      #
+      # It cannot fail a correct answer that words things differently: it matches
+      # no prose, reads { mps, blockDelta } pairs in JSON, JS and Python shapes with
+      # either casing, and passes outright when it can parse no schedule at all. See
+      # the header comment in the assertion file for the full reasoning.
+      - type: javascript
+        value: file://assertions/supply-schedule-total.js
+        metric: supply-schedule-totals-10m
+
       # Should not contain dangerous patterns
       - type: not-contains
         value: 'private key'

--- a/evals/suites/configurator/rubrics/completeness.txt
+++ b/evals/suites/configurator/rubrics/completeness.txt
@@ -42,8 +42,11 @@ Score based on how many of these are present:
 Deduct points for:
 - Exposing or requesting private keys directly (-0.15)
 - Incorrect decimal adjustment for currency (-0.15)
-- Supply schedule not summing to 10,000,000 MPS (-0.15)
 - Missing floor price divisibility verification (-0.1)
+
+Do NOT apply a penalty for the supply schedule failing to total 10,000,000 MPS.
+That total is exact arithmetic and is checked deterministically by a separate
+assertion, so scoring it here only adds noise.
 
 ## Scoring Guide
 

--- a/evals/suites/configurator/rubrics/correctness.txt
+++ b/evals/suites/configurator/rubrics/correctness.txt
@@ -17,10 +17,13 @@ Score based on how many of these are correctly implemented:
    - Verification: roundedFloorPrice % tickSpacing == 0
 
 3. **Supply Schedule**
-   - Schedule sums to exactly 10,000,000 MPS total
    - Block durations decrease over time (convex curve property)
    - Final block contains approximately 30% of supply
    - Each step releases approximately equal token amounts
+   - Do NOT score whether the schedule totals exactly 10,000,000 MPS. That total is
+     exact arithmetic, and it is checked deterministically by a separate assertion
+     that parses the emitted steps and sums mps * blockDelta. Judge only the shape
+     of the curve here, and treat the total as out of scope even if it is wrong.
 
 4. **Block Configuration**
    - Correct block time for network (2s for Base)

--- a/packages/plugins/uniswap-cca/.claude-plugin/plugin.json
+++ b/packages/plugins/uniswap-cca/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uniswap-cca",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Configure and deploy Continuous Clearing Auction (CCA) smart contracts for token distribution",
   "skills": ["./skills/configurator", "./skills/deployer"],
   "mcpServers": ["./.mcp.json"],

--- a/packages/plugins/uniswap-cca/CLAUDE.md
+++ b/packages/plugins/uniswap-cca/CLAUDE.md
@@ -102,7 +102,7 @@ Generates supply schedules using the normalized convex curve algorithm.
 - 12 steps (default) with equal token amounts (~5.8333% each)
 - Decreasing block durations (convex curve property)
 - ~30% in final block
-- Always exactly 10,000,000 MPS total
+- Always exactly 10,000,000 MPS total, computed as `sum(mps * blockDelta)`
 
 #### 2. encode_supply_schedule
 
@@ -183,7 +183,8 @@ Generates supply schedules using a **normalized convex curve**:
 - **Distribution**: Equal token amounts per step
 - **Time Intervals**: Decrease over time (convex curve property)
 - **Final Block**: ~30% of tokens (configurable 20-40%)
-- **Total**: Always exactly 10,000,000 MPS
+- **Total**: always exactly 10,000,000 MPS, computed as `sum(mps * blockDelta)`.
+  `mps` is a per-block release rate, so the `mps` column alone sums to far less.
 
 **Input Parameters:**
 
@@ -260,7 +261,7 @@ floorPrice = Q96 * ratio / (10 ** (18 - 6))
 Supply schedules use MPS = 1e7 (10 million):
 
 - Each MPS unit = one thousandth of a basis point
-- Target total: Always 10,000,000 MPS
+- Target total: always 10,000,000 MPS, computed as `sum(mps * blockDelta)`
 - Each schedule step: `{mps: N, blockDelta: N}`
 
 ### Supply Schedule Properties
@@ -270,7 +271,7 @@ Supply schedules use MPS = 1e7 (10 million):
 - Block durations DECREASE: 10894 → 8517 → 7803 → ... → 6043
 - Token amounts EQUAL: ~5.8333% per step
 - Final block: ~30% of total supply
-- Total: Exactly 10,000,000 MPS
+- Total: exactly 10,000,000 MPS, computed as `sum(mps * blockDelta)`
 
 ## Important Notes
 

--- a/packages/plugins/uniswap-cca/README.md
+++ b/packages/plugins/uniswap-cca/README.md
@@ -124,7 +124,8 @@ Generates supply schedules using a normalized convex curve.
 - **Distribution**: Equal token amounts per step (~5.8333% for 12 steps)
 - **Time Intervals**: Decrease over time (convex curve property)
 - **Final Block**: ~30% of tokens (configurable 20-40%)
-- **Total**: Always exactly 10,000,000 MPS
+- **Total**: always exactly 10,000,000 MPS, computed as `sum(mps * blockDelta)`.
+  `mps` is a per-block release rate, so the `mps` column alone sums to far less.
 
 **Tool:** `cca-supply-schedule__generate_supply_schedule`
 

--- a/packages/plugins/uniswap-cca/package.json
+++ b/packages/plugins/uniswap-cca/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uniswap/uniswap-cca",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "private": true,
   "description": "Configure and deploy Continuous Clearing Auction (CCA) smart contracts",
   "files": [

--- a/packages/plugins/uniswap-cca/skills/configurator/SKILL.md
+++ b/packages/plugins/uniswap-cca/skills/configurator/SKILL.md
@@ -538,7 +538,9 @@ The plugin includes an MCP server that generates supply schedules using a **norm
 - **Equal token amounts** per step (5.8333% for 70% gradual release)
 - **Decreasing block durations** (convex curve property)
 - **Large final block** receives remaining tokens (~30%, configurable 20-40%)
-- **Total**: Always exactly 10,000,000 MPS
+- **Total**: the released supply is always exactly 10,000,000 MPS, computed as
+  `sum(mps * blockDelta)` across every step. `mps` is a per-block release rate, not a
+  per-step amount, so the `mps` column by itself does not sum to 10,000,000.
 
 Use the MCP tool `generate_supply_schedule` to generate this standard distribution:
 
@@ -556,7 +558,7 @@ The algorithm automatically calculates:
 1. Equal token amounts per step (e.g., 5.8333% for 12 steps with 70% gradual)
 2. Time boundaries from normalized curve C(t) = t^α (default α = 1.2)
 3. Block durations that DECREASE over time (convex curve property)
-4. Final block adjustment to hit exactly 10,000,000 MPS total
+4. Final block adjustment so that `sum(mps * blockDelta)` is exactly 10,000,000 MPS
 
 ### Example: 2-day auction on Base
 
@@ -611,7 +613,7 @@ Call `generate_supply_schedule` with:
 - Block durations DECREASE: 10894 → 8517 → 7803 → ... → 6043
 - Token amounts per step are approximately equal (~5.8333% each)
 - Final block contains 29.88% of all tokens
-- Total is exactly 10,000,000 MPS
+- `sum(mps * blockDelta)` is exactly 10,000,000 MPS (the `mps` column alone sums to far less)
 
 ### Example: With prebid period
 


### PR DESCRIPTION
## Why

`Run Evaluations` is a required status check on `main`, and it is nondeterministic. Observed on PR #140:

- Run `31846203576` at `db97994`: configurator and deployer suites, 5/5 cases, every one scoring 1.0.
- Run `31848655116` at `e0d1192`, identical content (only a signing rebase changed the shas): `basic-configuration.md` failed. The correctness rubric scored 0.8 with the reason that the supply schedule summed to 9,999,996 MPS instead of exactly 10,000,000, four short.
- Re-running the same job passed.

The judge was right that time. The problem is that a property with exactly one correct answer was being decided by a sampled LLM judgment inside a blocking gate, so any PR touching the cca plugin can be stopped by chance, and "just re-run it" becomes the reflex. That reflex is how a genuine failure eventually gets waved through.

## What changed

A `javascript` assertion, `evals/suites/configurator/assertions/supply-schedule-total.js`, now decides the supply total.

**The total is not the sum of the `mps` fields.** The formula is the plugin's own, from `mcp-server/supply-schedule/server.py`:

```python
total_mps = sum(item["mps"] * item["blockDelta"] for item in schedule)
```

`mps` is a per-block release rate and `blockDelta` is how many blocks it runs for. In the skill's worked example the bare `mps` column sums to 2,989,006 while the products sum to exactly 10,000,000, so a check on the column alone would fail every correct answer.

Both rubrics now say explicitly not to score the total. That is a handoff rather than a relaxation, and the first CI run of this branch showed why (below).

## Why it cannot fail a correct answer worded differently

The suite's standing rule is that an assertion may only fail a wrong answer, and two earlier checks here broke it by matching wording (`AuctionParameters`, `educational`). This one:

1. Matches no prose. It reads only `{ mps, blockDelta }` pairs, in JSON, JS object literal and Python dict shapes, quoted or bare keys, camelCase or snake_case, either key order, numeric or string values. A lookbehind keeps `total_mps` from reading as `mps`.
2. **Passes when it can parse no schedule.** A correct answer that presents the schedule as a markdown table or in prose is not failed here. The existing `contains-any` check already requires the field to be named; this one grades arithmetic only when it can read it.
3. Considers several groupings (each contiguous block, all steps under a schedule key, all steps found) and needs only one to total correctly. Extra candidates can only turn a fail into a pass, so a grouping mistake cannot invent a failure.

## What CI actually found, and a correction to the premise above

Three runs on this branch, same unchanged prompt at `temperature: 0`:

| Run | `mps` reading | Released total | Rubrics | This assertion |
|---|---|---|---|---|
| `32086633973` | per-step | 50,402,995,375 (5,040x) | both 1.0, PASS | FAIL |
| `32087051353` | per-block rate | 10,000,000 exact | both 1.0, PASS | PASS |
| `32087348114` | per-step | 50,402,995,368 (5,040x) | both 1.0, PASS | FAIL |

The model flips between two readings of `mps`. Under the per-step reading it emits twelve steps at `583333` plus a large final step, which releases roughly five thousand times the auction supply. **Both LLM rubrics scored every one of those responses 1.0**, including the two that were catastrophically wrong. Only the deterministic assertion separated them.

**This also corrects the framing at the top of this description.** Run `32087348114`'s column sum is `583333 * 11 + 583337 + 2999996 = 9,999,996`, the exact figure the judge quoted when it failed PR #140. So that original failure was not a small rounding slip. It was this same per-step misreading, and the judge caught only the four-MPS discrepancy in the column while missing the 5,040x error sitting next to it. The rubric was less right than it looked.

**The check on this PR is currently red, and the red is correct.** The head commit's run produced an invalid schedule. Nothing here should be relaxed to turn it green: the assertion is doing the job it was added for. What the runs expose is a separate problem, that the skill and the case state the requirement as "sum to exactly 10,000,000 MPS" without naming the formula, and the model reads that as a column sum about half the time. Fixing that wording is a change to what the eval asks of the model, so it is deliberately not in this PR.

## Verification

Run locally against 11 hand-built responses, including the observed off-by-four failure, a comment-interrupted schedule, a prebid variant, a correct config alongside a quoted 3-step fragment, a markdown-table-only answer and a no-schedule refusal. Every correct or unparseable shape passed; only the arithmetically wrong ones failed.

The assertion also ran under promptfoo 0.121.11 itself with the `echo` provider, so no API key was needed, proving the `javascript` type loads this ESM file and returns the right verdicts. The full LLM eval could not be run locally; CI is where it first met a real model response.

Also ran: `nx format:check`, `markdownlint-cli2`, `prettier --check`, `eslint`, `promptfoo validate` on the changed and adjacent suites, and `check-eval-coverage.ts`.

## Deliberately out of scope

- The deployer suite does not grade this property: it produces a deployment guide, not a schedule. No other suite grades the MPS total.
- The case and the skill both state the requirement as "sum to exactly 10,000,000 MPS" without naming the formula, which is what invites the per-step reading. Clarifying that wording would change what the eval asks of the model, so it is left alone here.
